### PR TITLE
wrappers/helix: add package opt, rename "tomlGenerator" to "generator", rename "settingsFile" opt to "configFile" to match "settings" opt description

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -177,6 +177,10 @@
   },
 
   "helix": {
+    "configFile": {
+      "description": "`config.toml` file to be injected into the wrapped package. See the documentation for valid options: https://docs.helix-editor.com/configuration.html Disjoint with the `config` option.",
+      "type": "pathLike"
+    },
     "extraPackages": {
       "description": "Packages to be automatically added to helix's path. Mainly used to set language servers and formatters.",
       "type": "listOf<derivation>"
@@ -196,10 +200,6 @@
     "settings": {
       "description": "Settings to be injected into the wrapped package's `config.toml`. See the documentation: https://docs.helix-editor.com/configuration.html Disjoint with the `configFile` option.",
       "type": "attrs"
-    },
-    "settingsFile": {
-      "description": "`config.toml` file to be injected into the wrapped package. See the documentation for valid options: https://docs.helix-editor.com/configuration.html Disjoint with the `config` option.",
-      "type": "pathLike"
     },
     "themeDir": {
       "description": "Folder containing theme configuration files to be injected into the wrapped package. This folder should contain one or multiple `$theme_name.toml` files. Disjoint with the `themes` option.",

--- a/docs/options.json
+++ b/docs/options.json
@@ -189,6 +189,10 @@
       "description": "`languages.toml` file to be injected into the wrapped package. See the documentation on valid options: https://docs.helix-editor.com/languages.html Disjoint with the `languages` option.",
       "type": "pathLike"
     },
+    "package": {
+      "description": "The helix package to be wrapped.",
+      "type": "derivation"
+    },
     "settings": {
       "description": "Settings to be injected into the wrapped package's `config.toml`. See the documentation: https://docs.helix-editor.com/configuration.html Disjoint with the `configFile` option.",
       "type": "attrs"

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -22,7 +22,7 @@ in
         Disjoint with the `configFile` option.
       '';
     };
-    settingsFile = {
+    configFile = {
       type = types.pathLike;
       description = ''
         `config.toml` file to be injected into the wrapped package.
@@ -129,7 +129,7 @@ in
       '';
       symlinks = {
         "$out/helix/config.toml" =
-          if options ? settingsFile then
+          if options ? configFile then
             options.settingsFile
           else if options ? settings then
             generator.generate "config.toml" options.settings

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -99,7 +99,7 @@ in
       inherit (inputs.nixpkgs.pkgs) formats;
       inherit (builtins) listToAttrs attrNames;
       inherit (inputs.nixpkgs.lib) makeBinPath;
-      tomlGenerator = formats.toml { };
+      generator = formats.toml { };
       generatedThemes =
         if options ? themeDir then
           {
@@ -111,7 +111,7 @@ in
               name:
               {
                 name = "$out/helix/themes/${name}.toml";
-                value = tomlGenerator.generate "${name}.toml" options.themes.${name};
+                value = generator.generate "${name}.toml" options.themes.${name};
               }
             ) (attrNames options.themes)
           )
@@ -132,14 +132,14 @@ in
           if options ? settingsFile then
             options.settingsFile
           else if options ? settings then
-            tomlGenerator.generate "config.toml" options.settings
+            generator.generate "config.toml" options.settings
           else
             null;
         "$out/helix/languages.toml" =
           if options ? languagesFile then
             options.languagesFile
           else if options ? languages then
-            tomlGenerator.generate "languages.toml" options.languages
+            generator.generate "languages.toml" options.languages
           else
             null;
       }

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -33,6 +33,7 @@ in
         Disjoint with the `config` option.
       '';
     };
+
     themes = {
       type = types.attrsOf types.attrs;
       description = ''
@@ -54,6 +55,7 @@ in
         Disjoint with the `themes` option.
       '';
     };
+
     languages = {
       type = types.attrs;
       description = ''
@@ -76,18 +78,25 @@ in
         Disjoint with the `languages` option.
       '';
     };
+
     extraPackages = {
       type = types.listOf types.derivation;
       description = ''
         Packages to be automatically added to helix's path. Mainly used to set language servers and formatters.
       '';
     };
+
+    package = {
+      type = types.derivation;
+      description = "The helix package to be wrapped.";
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.helix;
+    };
   };
 
   impl =
     { options, inputs }:
     let
-      inherit (inputs.nixpkgs.pkgs) formats helix;
+      inherit (inputs.nixpkgs.pkgs) formats;
       inherit (builtins) listToAttrs attrNames;
       inherit (inputs.nixpkgs.lib) makeBinPath;
       tomlGenerator = formats.toml { };
@@ -113,7 +122,7 @@ in
     assert !(options ? themes && options ? themeDir);
     assert !(options ? languages && options ? languageDir);
     inputs.mkWrapper {
-      package = helix;
+      inherit (options) package;
       binaryPath = "$out/bin/hx";
       preWrap = ''
         mkdir -p $out/helix/themes


### PR DESCRIPTION
## Checklist

- [ x ] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [ x ] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ x ] I tested my wrapper to make sure it functioned
