### PR TITLE
wrappers/alacritty: make alacritty use the config in $out/alacritty

### DIFF
--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -43,8 +43,7 @@ in {
   impl =
     { options, inputs }:
     let
-      inherit (inputs.nixpkgs) pkgs;
-      generator = pkgs.formats.toml {};
+      generator = inputs.nixpkgs.pkgs.formats.toml {};
     in
     assert !(options ? settings && options ? configFile);
       inputs.mkWrapper {
@@ -60,5 +59,6 @@ in {
               then generator.generate "alacritty.toml" options.settings
             else null;
         };
+        flags = ["--config-file" "$out/alacritty/alacritty.toml"];
       };
 }


### PR DESCRIPTION
## Checklist

- [ x ] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [ x ] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ x ] I tested my wrapper to make sure it functioned
