### PR TITLE
wrappers/alacritty: refactor impl

### DIFF
--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -44,21 +44,11 @@ in {
     { options, inputs }:
     let
       generator = inputs.nixpkgs.pkgs.formats.toml {};
+      generatedConfig = options.configFile or (generator.generate "alacritty.toml" options.settings);
     in
     assert !(options ? settings && options ? configFile);
-      inputs.mkWrapper {
-        inherit (options) package;
-        preWrap = ''
-          mkdir -p $out/alacritty
-        '';
-        symlinks = {
-          "$out/alacritty/alacritty.toml" =
-            if options ? configFile
-              then options.configFile
-            else if options ? settings
-              then generator.generate "alacritty.toml" options.settings
-            else null;
-        };
-        flags = ["--config-file" "$out/alacritty/alacritty.toml"];
-      };
+    inputs.mkWrapper {
+      inherit (options) package;
+      flags = ["--config-file" "${generatedConfig}"];
+    };
 }


### PR DESCRIPTION
simplify wrapping, there's no need of making a dir and a symlink for something that can be done with just a flag that points to the generated config in the nix store

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
