### PR TITLE
make nushell use the same flags syntax as waybar

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -325,11 +325,6 @@
   },
 
   "nushell": {
-    "config": {
-      "description": "Config to be injected into the wrapped package's `config.nu`. See the nushell documentation for valid options: https://www.nushell.sh/book/configuration.html Disjoint with the `configFile` option.",
-      "mutatorType": "string",
-      "type": "string"
-    },
     "configFile": {
       "description": "`config.nu` file to be injected into the wrapped package. See the nushell documentation on file syntax: https://www.nushell.sh/book/configuration.html Disjoint with the `config` option.",
       "type": "pathLike"
@@ -346,6 +341,11 @@
     "package": {
       "description": "The nushell package to be wrapped.",
       "type": "derivation"
+    },
+    "settings": {
+      "description": "Config to be injected into the wrapped package's `config.nu`. See the nushell documentation for valid options: https://www.nushell.sh/book/configuration.html Disjoint with the `configFile` option.",
+      "mutatorType": "string",
+      "type": "string"
     }
   },
 


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
