### PR TITLE
treewide: reformat

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,4 +33,4 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Check that all modules are formatted properly
-        run: nix-shell --expr "with import <nixpkgs> {}; callPackage ./dev/nixfmt.nix {}" --run "nixfmt --check ./modules"
+        run: nix-shell -p "callPackage ./dev/nixfmt.nix {}" --command "nixfmt --check ./modules"

--- a/dev/_get-docs.nix
+++ b/dev/_get-docs.nix
@@ -2,18 +2,19 @@ let
   inherit (builtins) mapAttrs getFlake;
   optionalAttrs = cond: attrs: if cond then attrs else {};
 in
+mapAttrs (
+  _: wrapper:
   mapAttrs (
-    _: wrapper:
-    mapAttrs (
-      _: option:
-      (removeAttrs option [
-        "defaultFunc"
-        "mergeFunc"
-      ])
-      // {
-        type = option.type.name;
-      } // optionalAttrs (option ? mutatorType) {
-        mutatorType = option.mutatorType.name;
-      }
-    ) wrapper.options
-  ) (getFlake (toString ../.)).wrapperModules
+    _: option:
+    (removeAttrs option [
+      "defaultFunc"
+      "mergeFunc"
+    ])
+    // {
+      type = option.type.name;
+    }
+    // optionalAttrs (option ? mutatorType) {
+      mutatorType = option.mutatorType.name;
+    }
+  ) wrapper.options
+) (getFlake (toString ../.)).wrapperModules

--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -60,6 +60,6 @@ in {
           else
             null;
       };
-      flags = ["--config-file" "$out/alacritty/alacritty.toml"];
+      flags = [ "--config-file $out/alacritty/alacritty.toml" ];
     };
 }

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -1,8 +1,7 @@
 { adios }:
 let
   inherit (adios) types;
-in
-{
+in {
   name = "bottom";
 
   inputs = {
@@ -44,7 +43,7 @@ in
   impl =
     { options, inputs }:
     let
-      generator = inputs.nixpkgs.pkgs.formats.toml { };
+      generator = inputs.nixpkgs.pkgs.formats.toml {};
     in
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {

--- a/modules/discordo.nix
+++ b/modules/discordo.nix
@@ -52,42 +52,41 @@ in {
 
     package = {
       type = types.derivation;
-      defaultFunc = {inputs}: inputs.nixpkgs.pkgs.discordo;
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.discordo;
       description = "The discordo package to be wrapped.";
     };
   };
 
-  impl = {
-    options,
-    inputs,
-  }: let
-    generator = inputs.nixpkgs.pkgs.formats.toml {};
-  in
+  impl =
+    { options, inputs }:
+    let
+      generator = inputs.nixpkgs.pkgs.formats.toml {};
+    in
     assert !(options ? settings && options ? configFile);
-      inputs.mkWrapper {
-        inherit (options) package flags;
-        preWrap = ''
-          mkdir -p $out/discordo/
-        '';
-        environment = {
-          XDG_CONFIG_HOME = "$out";
-          DISCORDO_TOKEN =
-            if options ? tokenFile then
-              {
-                value = options.tokenFile;
-                readFromFile = true;
-              }
-            else
-              null;
-        };
-        symlinks = {
-          "$out/discordo/config.toml" =
-            if options ? configFile then
-              options.configFile
-            else if options ? settings then
-              generator.generate "config.toml" options.settings
-            else
-              null;
-        };
+    inputs.mkWrapper {
+      inherit (options) package flags;
+      preWrap = ''
+        mkdir -p $out/discordo/
+      '';
+      environment = {
+        XDG_CONFIG_HOME = "$out";
+        DISCORDO_TOKEN =
+          if options ? tokenFile then
+            {
+              value = options.tokenFile;
+              readFromFile = true;
+            }
+          else
+            null;
       };
+      symlinks = {
+        "$out/discordo/config.toml" =
+          if options ? configFile then
+            options.configFile
+          else if options ? settings then
+            generator.generate "config.toml" options.settings
+          else
+            null;
+      };
+    };
 }

--- a/modules/fish.nix
+++ b/modules/fish.nix
@@ -86,15 +86,19 @@ in {
             expansion = types.string;
           };
           # Just renamed for a nicer internal name
-          abbrType = types.rename "abbr" (types.union [
-            types.string
-            (abbrWithCursor.override { unknown = false; })
-          ]);
+          abbrType = types.rename "abbr" (
+            types.union [
+              types.string
+              (abbrWithCursor.override { unknown = false; })
+            ]
+          );
         in
-        types.attrsOf (types.union [
-          abbrType
-          (types.listOf (types.attrsOf abbrType))
-        ]);
+        types.attrsOf (
+          types.union [
+            abbrType
+            (types.listOf (types.attrsOf abbrType))
+          ]
+        );
       mergeFunc =
         { mutators, inputs }:
         let
@@ -148,7 +152,9 @@ in {
           inherit (builtins) attrValues concatStringsSep;
         in
         concatStringsSep "\n" (
-          [ "status is-interactive || exit 0" ]
+          [
+            "status is-interactive || exit 0"
+          ]
           ++ attrValues mutators
           ++ [ options.abbreviations ]
         );

--- a/modules/mkWrapper/default.nix
+++ b/modules/mkWrapper/default.nix
@@ -50,22 +50,26 @@ in {
       default = "";
     };
     environment = {
-      type = types.attrsOf (types.union [
-        types.null
-        types.pathLike
-        (types.struct "readFromFileAtRuntime" {
-          readFromFile = types.bool;
-          value = types.pathLike;
-        })
-      ]);
+      type = types.attrsOf (
+        types.union [
+          types.null
+          types.pathLike
+          (types.struct "readFromFileAtRuntime" {
+            readFromFile = types.bool;
+            value = types.pathLike;
+          })
+        ]
+      );
       description = "Environment variables to be set during the execution of the wrapped program";
       default = {};
     };
     symlinks = {
-      type = types.attrsOf (types.union [
-        types.null
-        types.pathLike
-      ]);
+      type = types.attrsOf (
+        types.union [
+          types.null
+          types.pathLike
+        ]
+      );
       description = ''
         Symlinks to be included in the resulting derivation.
         Each key specifies the location within the derivation to create the symlink.
@@ -112,9 +116,7 @@ in {
             [ "ln -s ${destination} ${symlink}" ]
         ) (attrNames options.symlinks)
       );
-      flagsStr = concatStringsSep " " (
-        map (flag: "--add-flag \"${flag}\"") options.flags
-      );
+      flagsStr = concatStringsSep " " (map (flag: "--add-flag \"${flag}\"") options.flags);
     in
     stdenvNoCC.mkDerivation {
       name = "${options.name}-wrapped";

--- a/modules/starship.nix
+++ b/modules/starship.nix
@@ -64,7 +64,9 @@ in {
         in
         # Allow mutators to change the default value, with the mutators taking
         # priority if the key is the same
-        recursiveUpdate default (mergeAttrsRecursively { inherit mutators; });
+        recursiveUpdate default (mergeAttrsRecursively {
+          inherit mutators;
+        });
     };
 
     package = {

--- a/modules/waybar.nix
+++ b/modules/waybar.nix
@@ -106,9 +106,6 @@ in {
       inherit (options) package;
       flags = configFlag ++ styleFlag;
       environment.GTK_DEBUG =
-      if options ? interactiveEnv && options.interactiveEnv then
-        "interactive"
-      else
-        null;
+        if options ? interactiveEnv && options.interactiveEnv then "interactive" else null;
     };
 }


### PR DESCRIPTION
Putting this in a PR to test the new formatting check.

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
