### PR TITLE
wrappers/zellij: init

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -527,6 +527,33 @@
     }
   },
 
+  "zellij": {
+    "configContents": {
+      "description": "Config to be injected into the wrapped package's `config.kdl`. See the documentation for valid options: https://zellij.dev/documentation/configuration.html Disjoint with the `configFile` option.",
+      "type": "string"
+    },
+    "configFile": {
+      "description": "`config.kdl` file to be injected into the wrapped package. See the documentation for valid options: https://zellij.dev/documentation/configuration.html Disjoint with the `configContents` option.",
+      "type": "pathLike"
+    },
+    "layoutsContents": {
+      "description": "Custom layouts to be injected into the wrapped package. See the documentation to learn how to make custom layouts and use them: https://zellij.dev/documentation/layouts.html Disjoint with the `layoutsFiles` option.",
+      "type": "attrsOf<string>"
+    },
+    "layoutsFiles": {
+      "description": "Files containing custom layouts to be injected into the wrapped package. See the documentation to learn how to make custom layouts and use them: https://zellij.dev/documentation/layouts.html Disjoint with the `layoutsContents` option.",
+      "type": "listOf<pathLike>"
+    },
+    "package": {
+      "description": "The zellij package to be wrapped.",
+      "type": "derivation"
+    },
+    "themes": {
+      "description": "Attribute set of themes to be injected into the wrapped package. See the zellij documentation to learn how to make custom themes and use them: https://zellij.dev/documentation/themes.html Each attribute name is used as the theme name. The corresponding value must be a folder or derivation whose top level contains a file named `<name>.kdl`. For example, an entry `themes.dracula = <drv>;` where `<drv>` contains `dracula.kdl` will result in `themes/dracula.kdl`.",
+      "type": "attrsOf<pathLike>"
+    }
+  },
+
   "zoxide": {
     "excludedDirs": {
       "description": "Directory globs that won't be added to the database when navigating with zoxide.",

--- a/modules/zellij.nix
+++ b/modules/zellij.nix
@@ -1,0 +1,137 @@
+{ adios }:
+let
+  inherit (adios) types;
+in {
+  name = "zellij";
+
+  inputs = {
+    mkWrapper.path = "/mkWrapper";
+    nixpkgs.path = "/nixpkgs";
+  };
+
+  # The reason for there not being RFC42 options like `settings` or `layouts` is
+  # because KDL is xml-like meaning there's no one way of it being encoded to
+  # something like Nix.
+  options = {
+    configContents = {
+      type = types.string;
+      description = ''
+        Config to be injected into the wrapped package's `config.kdl`.
+
+        See the documentation for valid options:
+        https://zellij.dev/documentation/configuration.html
+
+        Disjoint with the `configFile` option.
+      '';
+    };
+    configFile = {
+      type = types.pathLike;
+      description = ''
+        `config.kdl` file to be injected into the wrapped package.
+
+        See the documentation for valid options:
+        https://zellij.dev/documentation/configuration.html
+
+        Disjoint with the `configContents` option.
+      '';
+    };
+
+    layoutsContents = {
+      type = types.attrsOf types.str;
+      description = ''
+        Custom layouts to be injected into the wrapped package.
+
+        See the documentation to learn how to make custom layouts and use them:
+        https://zellij.dev/documentation/layouts.html
+
+        Disjoint with the `layoutsFiles` option.
+      '';
+    };
+    layoutsFiles = {
+      type = types.listOf types.pathLike;
+      description = ''
+        Files containing custom layouts to be injected into the wrapped package.
+
+        See the documentation to learn how to make custom layouts and use them:
+        https://zellij.dev/documentation/layouts.html
+
+        Disjoint with the `layoutsContents` option.
+      '';
+    };
+
+    themes = {
+      type = types.attrsOf types.pathLike;
+      description = ''
+        Attribute set of themes to be injected into the wrapped package.
+
+        See the zellij documentation to learn how to make custom themes and use them:
+        https://zellij.dev/documentation/themes.html
+
+        Each attribute name is used as the theme name. The corresponding value must be
+        a folder or derivation whose top level contains a file named `<name>.kdl`.
+
+        For example, an entry `themes.dracula = <drv>;` where `<drv>` contains
+        `dracula.kdl` will result in `themes/dracula.kdl`.
+      '';
+    };
+
+    package = {
+      type = types.derivation;
+      description = "The zellij package to be wrapped.";
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.zellij;
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      inherit (builtins) listToAttrs attrNames;
+      inherit (inputs.nixpkgs.pkgs) writeText;
+      optionalAttrs = cond: attrs: if cond then attrs else {};
+    in
+    inputs.mkWrapper {
+      inherit (options) package;
+      preWrap = ''
+        mkdir -p $out/zellij-config/themes
+        mkdir -p $out/zellij-config/layouts
+      '';
+      symlinks = {
+        "$out/zellij-config/config.kdl" =
+          if options ? configFile then
+            options.configFile
+          else if options ? configContents then
+            writeText "config.kdl" options.configContents
+          else
+            null;
+      }
+      // (
+        if options ? layoutsFiles then
+          listToAttrs (
+            map (path: {
+              name = "$out/zellij-config/layouts/${baseNameOf path}";
+              value = path;
+            }) options.layoutsFiles
+          )
+        else if options ? layoutsContents then
+          listToAttrs (
+            map (path: {
+              name = "$out/zellij-config/layouts/${path}.kdl";
+              value = writeText path options.layoutsContents.${path};
+            }) (attrNames options.layoutsContents)
+          )
+        else
+          {}
+      )
+      // optionalAttrs (options ? themes) (
+        listToAttrs (
+          map (name: {
+            name = "$out/zellij-config/themes/${name}.kdl";
+            value = "${name}/${name}.kdl";
+          }) (attrNames options.themes)
+        )
+      );
+      environment = {
+        ZELLIJ_CONFIG_DIR = "$out/zellij-config";
+      };
+    };
+}


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
