### PR TITLE
wrappers/yazi: fix missing dependency

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -478,7 +478,7 @@
 
   "yazi": {
     "extraPackages": {
-      "description": "Packages to be automatically added as Yazi dependencies. This defaults to the optionalDeps of the Yazi package in nixpkgs, set here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ya/yazi/package.nix#L8",
+      "description": "Packages to be automatically added as Yazi dependencies. This defaults to the optionalDeps of the Yazi package in nixpkgs, set here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ya/yazi/package.nix#L8 The dependency `File` is added regardless of the content of this option, because it's non-optional. See the Yazi docs on this topic: https://yazi-rs.github.io/docs/installation",
       "type": "listOf<derivation>"
     },
     "flavors": {

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -109,6 +109,10 @@ in {
 
         This defaults to the optionalDeps of the Yazi package in nixpkgs, set here:
         https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ya/yazi/package.nix#L8
+
+        The dependency `File` is added regardless of the content of this option, because it's non-optional.
+        See the Yazi docs on this topic:
+        https://yazi-rs.github.io/docs/installation
       '';
       defaultFunc =
         { inputs }:
@@ -155,11 +159,11 @@ in {
   impl =
     { inputs, options }:
     let
+      inherit (inputs.nixpkgs) pkgs;
       inherit (inputs.nixpkgs.lib) makeBinPath;
-      inherit (inputs.nixpkgs.pkgs) formats;
       inherit (builtins) listToAttrs attrNames;
       optionalAttrs = cond: attrs: if cond then attrs else {};
-      generator = formats.toml {};
+      generator = pkgs.formats.toml {};
     in
     assert !(options ? settings && options ? settingsFile);
     assert !(options ? keymap && options ? keymapFile);
@@ -217,7 +221,7 @@ in {
         )
       );
       wrapperArgs = ''
-        --prefix PATH : ${makeBinPath options.extraPackages}
+        --prefix PATH : ${makeBinPath (options.extraPackages ++ [ pkgs.file ])}
       '';
       environment = {
         YAZI_CONFIG_HOME = "$out/yazi";


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
