### PR TITLE
wrappers/zellij: add assertions

### DIFF
--- a/modules/zellij.nix
+++ b/modules/zellij.nix
@@ -89,6 +89,8 @@ in {
       inherit (inputs.nixpkgs.pkgs) writeText;
       optionalAttrs = cond: attrs: if cond then attrs else {};
     in
+    assert !(options ? configContents && options ? configFile);
+    assert !(options ? layoutsContents && options ? layoutsFiles);
     inputs.mkWrapper {
       inherit (options) package;
       preWrap = ''


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
