### PR TITLE
nushell: fix several typos, and replace env-config with string

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -369,21 +369,12 @@
       "description": "`config.nu` file to be injected into the wrapped package. See the nushell documentation on file syntax: https://www.nushell.sh/book/configuration.html Disjoint with the `config` option.",
       "type": "pathLike"
     },
-    "environment": {
-      "description": "Attrset of environment variables to be injected into the wrapped packages `config.nu`. See the nushell documentation for valid options: https://www.nushell.sh/book/configuration.html Example: ``` {   HELLO = \"test\";   FOO = \"3\"; } ``` Maps to: ``` $env.HELLO = \"test\" $env.FOO = \"3\" ``` Disjoint with the `environmentFile` option.",
-      "mutatorType": "attrs",
-      "type": "attrs"
-    },
-    "environmentFile": {
-      "description": "`env.nu` file to be injected into the wrapped package. See the nushell documentaion on file sytax: https://www.nushell.sh/book/configuration.html Disjoint with the `environment` option.",
-      "type": "pathLike"
-    },
     "package": {
       "description": "The nushell package to be wrapped.",
       "type": "derivation"
     },
-    "settings": {
-      "description": "Config to be injected into the wrapped package's `config.nu`. See the nushell documentation for valid options: https://www.nushell.sh/book/configuration.html Disjoint with the `configFile` option.",
+    "shellInit": {
+      "description": "Shell initialisation code to be injected into the wrapped package's `config.nu`. See the nushell documentation for valid options: https://www.nushell.sh/book/configuration.html Disjoint with the `configFile` option.",
       "mutatorType": "string",
       "type": "string"
     }


### PR DESCRIPTION
## Checklist
split out from [25](https://github.com/llakala/adios-wrappers/pull/25)

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
