### PR TITLE
helix: fix assert for languages being broken

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -216,7 +216,7 @@
       "type": "listOf<derivation>"
     },
     "languages": {
-      "description": "Languages to be injected into the wrapped package's `languages.toml`. See the documentation for valid options: https://docs.helix-editor.com/languages.html Disjoint with the `languagesFile` option.",
+      "description": "Language config to be injected into the wrapped package's `languages.toml`. See the documentation for valid options: https://docs.helix-editor.com/languages.html Disjoint with the `languagesFile` option.",
       "type": "attrs"
     },
     "languagesFile": {

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -58,7 +58,7 @@ in {
     languages = {
       type = types.attrs;
       description = ''
-        Languages to be injected into the wrapped package's `languages.toml`.
+        Language config to be injected into the wrapped package's `languages.toml`.
 
         See the documentation for valid options:
         https://docs.helix-editor.com/languages.html
@@ -114,9 +114,9 @@ in {
         else
           {};
     in
-    assert !(options ? config && options ? configFile);
+    assert !(options ? settings && options ? configFile);
     assert !(options ? themes && options ? themeDir);
-    assert !(options ? languages && options ? languageDir);
+    assert !(options ? languages && options ? languagesFile);
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/hx";


### PR DESCRIPTION
## Checklist
split out from [25](https://github.com/llakala/adios-wrappers/pull/25)

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
