### PR TITLE
mkWrapper: add new build phase before wrap and rename preWrap -> preSymlink

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -332,6 +332,12 @@
       "description": "Commands to be run after the wrapping process in the build steps.",
       "type": "union<null,string>"
     },
+    "preSymlink": {
+      "default": null,
+      "description": "Commands to be run before the symlinking process in the build steps. Commonly used to create a directory in which the symlinks will be placed.",
+      "example": "mkdir -p $out/foo-config",
+      "type": "union<null,string>"
+    },
     "preWrap": {
       "default": null,
       "description": "Commands to be run before the wrapping process in the build steps.",

--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -48,7 +48,7 @@ in {
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/alacritty
       '';
       symlinks = {

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -49,7 +49,7 @@ in {
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/btm";
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/bottom
       '';
       symlinks = {

--- a/modules/discordo.nix
+++ b/modules/discordo.nix
@@ -66,7 +66,7 @@ in {
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package flags;
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/discordo/
       '';
       environment = {

--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -55,7 +55,7 @@ in {
     assert !(options ? themeConfig && options ? themeFile);
     inputs.mkWrapper {
       inherit (options) package flags;
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/eza-config
       '';
       symlinks = {

--- a/modules/gh.nix
+++ b/modules/gh.nix
@@ -83,7 +83,7 @@ in {
     else
       inputs.mkWrapper {
         inherit (options) package;
-        preWrap = ''
+        preSymlink = ''
           mkdir -p $out/gh
         '';
         symlinks = {

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -80,7 +80,7 @@ in {
     inputs.mkWrapper {
       name = "git"; # Default derivation name is git-with-svn
       inherit (options) package;
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/git
       '';
       symlinks = {

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -120,7 +120,7 @@ in {
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/hx";
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/helix/themes
       '';
       symlinks = {

--- a/modules/jujutsu.nix
+++ b/modules/jujutsu.nix
@@ -60,7 +60,7 @@ in {
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/jj";
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/jj-config
       '';
       symlinks = {

--- a/modules/kitty.nix
+++ b/modules/kitty.nix
@@ -93,7 +93,7 @@ in {
     assert !(options ? theme && options ? themeFile);
     inputs.mkWrapper {
       inherit (options) package;
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/kitty
       '';
       symlinks = {

--- a/modules/mkWrapper/default.nix
+++ b/modules/mkWrapper/default.nix
@@ -40,6 +40,16 @@ in {
       defaultFunc = { options }: "$out/bin/${options.name}";
     };
 
+    preSymlink = {
+      type = nullOr types.string;
+      description = ''
+        Commands to be run before the symlinking process in the build steps. Commonly used to create a directory in which the symlinks will be placed.
+      '';
+      default = null;
+      example = ''
+        mkdir -p $out/foo-config
+      '';
+    };
     preWrap = {
       type = nullOr types.string;
       description = "Commands to be run before the wrapping process in the build steps.";
@@ -140,8 +150,9 @@ in {
         for i in $(cat $pathsPath); do
           ${lndir}/bin/lndir -silent $i $out
         done
-        ${optionalString options.preWrap}
+        ${optionalString options.preSymlink}
         ${symlinkedStr}
+        ${optionalString options.preWrap}
         ${
           if environmentStr == "" && options.wrapperArgs == "" && options.flags == [] then
             ""

--- a/modules/tealdeer.nix
+++ b/modules/tealdeer.nix
@@ -49,7 +49,7 @@ in {
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/tldr";
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/tealdeer-config
       '';
       symlinks = {

--- a/modules/termfilechooser.nix
+++ b/modules/termfilechooser.nix
@@ -45,7 +45,7 @@ in {
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/libexec/xdg-desktop-portal-termfilechooser";
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/xdg-desktop-portal-termfilechooser
       '';
       symlinks = {

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -170,7 +170,7 @@ in {
     assert !(options ? initLua && options ? initLuaFile);
     inputs.mkWrapper {
       inherit (options) package;
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/yazi/plugins
         mkdir -p $out/yazi/flavors
       '';

--- a/modules/zellij.nix
+++ b/modules/zellij.nix
@@ -93,7 +93,7 @@ in {
     assert !(options ? layoutsContents && options ? layoutsFiles);
     inputs.mkWrapper {
       inherit (options) package;
-      preWrap = ''
+      preSymlink = ''
         mkdir -p $out/zellij-config/themes
         mkdir -p $out/zellij-config/layouts
       '';


### PR DESCRIPTION
This PR adds a new phase to the mkWrapper build command (preWrap) that occurs before the wrapping phase but after the symlinking phase. The previous `preWrap` that occurred prior to symlinking has been renamed to `preSymlink` and all affected modules have been updated to reflect the name change..

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
