### PR TITLE
modules: use new semantics for file parameters

### DIFF
--- a/dev/nixfmt.nix
+++ b/dev/nixfmt.nix
@@ -4,7 +4,7 @@ nixfmt.overrideAttrs {
   src = fetchFromGitHub {
     owner = "llakala";
     repo = "nixfmt";
-    rev = "45e43e0804c81ca7eef84d823d9eb1a43a96bf0a";
-    hash = "sha256-4+V35M39Pc4tiEkWn7n/sK2FQ9bB94baSJ857xhGEyw=";
+    rev = "66d35eddc8ccbe833a8fbac9cd3a3e0015283d97";
+    hash = "sha256-1UE28LaQLKR2ZnHts7Sz2hIyZnaVz14s45A9LfNi60A=";
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "adios": {
       "locked": {
-        "lastModified": 1769454277,
-        "narHash": "sha256-Qkht1VcmVosPbvNWtgRFTGJTK+ES9h3ukctkKxevKuo=",
+        "lastModified": 1769580330,
+        "narHash": "sha256-rKcmnyW1Wd3MLpVg8+afu2m8SL+CnCiqNNYmZHgqsXo=",
         "owner": "llakala",
         "repo": "adios",
-        "rev": "bd2a40646a6dc8c6a5a1252911b81d700cababf3",
+        "rev": "afc20fccb37766259908482bfd59139b2ad6828e",
         "type": "github"
       },
       "original": {

--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "alacritty";
 
   inputs = {

--- a/modules/bat.nix
+++ b/modules/bat.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "bat";
 
   inputs = {

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "bottom";
 
   inputs = {

--- a/modules/diff-so-fancy.nix
+++ b/modules/diff-so-fancy.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "diff-so-fancy";
 
   inputs = {

--- a/modules/discordo.nix
+++ b/modules/discordo.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "discordo";
 
   inputs = {

--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "eza";
 
   inputs = {

--- a/modules/firefox.nix
+++ b/modules/firefox.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "firefox";
 
   inputs = {

--- a/modules/fish.nix
+++ b/modules/fish.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... } @ adios:
+{
   name = "fish";
 
   inputs = {

--- a/modules/fuzzel.nix
+++ b/modules/fuzzel.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "fuzzel";
 
   inputs = {

--- a/modules/gh.nix
+++ b/modules/gh.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "gh";
 
   inputs = {

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... } @ adios:
+{
   name = "git";
 
   inputs = {

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "helix";
 
   inputs = {

--- a/modules/jujutsu.nix
+++ b/modules/jujutsu.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "jujutsu";
 
   inputs = {

--- a/modules/kitty.nix
+++ b/modules/kitty.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "kitty";
 
   inputs = {

--- a/modules/less.nix
+++ b/modules/less.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "less";
 
   inputs = {

--- a/modules/mkWrapper/default.nix
+++ b/modules/mkWrapper/default.nix
@@ -1,6 +1,5 @@
-{ adios }:
+{ types, ... }:
 let
-  inherit (adios) types;
   nullOr =
     other:
     types.union [

--- a/modules/nixpkgs.nix
+++ b/modules/nixpkgs.nix
@@ -1,13 +1,13 @@
-{ adios }:
+{ types, ... }:
 {
   name = "nixpkgs";
 
   options = {
     pkgs = {
-      type = adios.types.attrs;
+      type = types.attrs;
     };
     lib = {
-      type = adios.types.attrs;
+      type = types.attrs;
       defaultFunc = { options }: options.pkgs.lib;
     };
   };

--- a/modules/nushell.nix
+++ b/modules/nushell.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... } @ adios:
+{
   name = "nushell";
 
   inputs = {

--- a/modules/ripgrep.nix
+++ b/modules/ripgrep.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "ripgrep";
 
   inputs = {

--- a/modules/starship.nix
+++ b/modules/starship.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... } @ adios:
+{
   name = "starship";
 
   inputs = {

--- a/modules/swaybg.nix
+++ b/modules/swaybg.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "swaybg";
 
   inputs = {

--- a/modules/swayidle.nix
+++ b/modules/swayidle.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "swayidle";
 
   inputs = {

--- a/modules/tealdeer.nix
+++ b/modules/tealdeer.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "tealdeer";
 
   inputs = {

--- a/modules/termfilechooser.nix
+++ b/modules/termfilechooser.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "termfilechooser";
 
   inputs = {

--- a/modules/waybar.nix
+++ b/modules/waybar.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "waybar";
 
   inputs = {

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "yazi";
 
   inputs = {

--- a/modules/zellij.nix
+++ b/modules/zellij.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "zellij";
 
   inputs = {

--- a/modules/zoxide.nix
+++ b/modules/zoxide.nix
@@ -1,7 +1,5 @@
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... }:
+{
   name = "zoxide";
 
   inputs = {

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -1,8 +1,6 @@
 # TODO integration with zoxide, plugins, etc
-{ adios }:
-let
-  inherit (adios) types;
-in {
+{ types, ... } @ adios:
+{
   name = "zsh";
 
   inputs = {


### PR DESCRIPTION
In the newest Adios commit, importModules now passes each file `adios` directly, rather than `{ adios }`. This means we can do a lot of nice stuff with destructors and take the specific values we want. Most modules will only take `{ types, ... }:`, but some modules that use something from `adios.lib` want to refer to adios itself, while inheriting types, and _not_ inheriting lib. To do this, we do `{ types, ... } @ adios:`.

Along with this, we bump the formatter to a new commit, that handles `@` properly.

I chose not to commit this to main directly, since it's quite involved (touches every single module), and I have an illogical fear that I messed up on a file. Before I merge, I'd appreciate some review - basically just go through the files and make sure I really didn't miss anything that would cause an error.

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json` (I didn't change any)
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it (I wrote it!)
- [x] I tested my wrapper to make sure it functioned (I tested _all_ my wrappers and my devshell builds fine)