### PR TITLE
modules/zsh: enable more complex nix configuration

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -635,18 +635,30 @@
   },
 
   "zsh": {
+    "aliases": {
+      "description": "Aliases to be defined in the wrapped package's `.zshrc` file. Aliases can either be a string defining the command to be aliased, or a struct where you can define the command and if the alias should be global. See the documentation for valid options: https://zsh.sourceforge.io/Intro/intro_8.html",
+      "example": {
+        "G": {
+          "command": "| grep",
+          "global": true
+        },
+        "ls": "ls --color"
+      },
+      "mutatorType": "attrsOf<union<string,global alias>>",
+      "type": "attrsOf<union<string,global alias>>"
+    },
     "extraPackages": {
       "description": "Runtime dependencies to be injected into the wrapped package's path.",
-      "mutatorType": "listOf<pathLike>",
+      "mutatorType": "listOf<derivation>",
       "type": "listOf<derivation>"
     },
     "extraZshrc": {
-      "description": "zsh script to be injected at the end of the wrapped package's `.zshrc`. Disjoint with the `zshrcFiles` option.",
-      "mutatorType": "string",
+      "description": "zsh script to be injected after the `zshrcFiles` option in the wrapped package's `.zshrc`.",
+      "example": "# zoxide must be added at the end of the .zshrc so we use extraZshrc. # https://github.com/ajeetdsouza/zoxide?tab=readme-ov-file#installation eval \"$(zoxide init zsh)\"",
       "type": "string"
     },
     "extraZshrcFiles": {
-      "description": "zsh files to be sourced at the end of the wrapped package's `.zshrc` file. Disjoint with the `zshrc` option.:",
+      "description": "zsh files to be sourced at the end of the wrapped package's `.zshrc` file.",
       "mutatorType": "listOf<pathLike>",
       "type": "listOf<pathLike>"
     },
@@ -654,13 +666,39 @@
       "description": "The zsh package to be wrapped.",
       "type": "derivation"
     },
+    "plugins": {
+      "description": "Plugins to be appended to the wrapped package's `.zshrc`. If a value is a derivation, it will be sourced as `<derivation>/share/<derivation.pname>/<derivation.pname>.zsh` which should be compatible with the majority of plugins. If this path is incorrect then the value may be defined as an attrSet containing the attrs `package` and `path` and will be sourced as `<package>/<path>`.",
+      "example": "[   pkgs.zsh-autosuggestions   {     package = pkgs.nix-zsh-completions;     path = \"share/zsh/plugins/nix/nix-zsh-completions.plugin.zsh\";   } ];",
+      "mutatorType": "listOf<union<derivation,plugin>>",
+      "type": "listOf<union<derivation,plugin>>"
+    },
+    "settings": {
+      "description": "Options to be enabled or disabled in the wrapped package's `.zshrc` file. See the documentation for valid options: https://zsh.sourceforge.io/Doc/Release/Options.html",
+      "example": {
+        "appendhistory": true,
+        "autocd": false,
+        "beep": false,
+        "sharehistory": true
+      },
+      "mutatorType": "attrsOf<bool>",
+      "type": "attrsOf<bool>"
+    },
+    "variables": {
+      "description": "Environment variables to be defined in the wrapped package's `.zshrc` file.",
+      "example": {
+        "HISTFILE": "~/.histfile",
+        "HISTSIZE": 5000
+      },
+      "mutatorType": "attrs",
+      "type": "attrs"
+    },
     "zshrc": {
-      "description": "zsh script to be injected into the wrapped package's `.zshrc`. Disjoint with the `zshrcFiles` option.",
-      "mutatorType": "string",
+      "description": "zsh script to be injected into the wrapped package's `.zshrc`.",
+      "example": "# Enable vim mode bindkey -v # Enable completions. A custom zcompdump location must be used as the # default location will be $ZDOTDIR which is immutable. autoload -Uz compinit compinit -d ~/.cache/zsh/.zcompdump -C",
       "type": "string"
     },
     "zshrcFiles": {
-      "description": "zsh files to be sourced in the wrapped package's `.zshrc` file. Disjoint with the `zshrc` option.",
+      "description": "zsh files to be sourced after the `zshrc` option in the wrapped package's `.zshrc` file.",
       "mutatorType": "listOf<pathLike>",
       "type": "listOf<pathLike>"
     }

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -1,4 +1,3 @@
-# TODO integration with zoxide, plugins, etc
 { types, ... } @ adios:
 {
   name = "zsh";
@@ -13,49 +12,153 @@
       type = types.string;
       description = ''
         zsh script to be injected into the wrapped package's `.zshrc`.
-
-        Disjoint with the `zshrcFiles` option.
       '';
-      mutatorType = types.string;
-      mergeFunc = adios.lib.merge.strings.concatLines;
+      example = ''
+        # Enable vim mode
+        bindkey -v
+
+        # Enable completions. A custom zcompdump location must be used as the
+        # default location will be $ZDOTDIR which is immutable.
+        autoload -Uz compinit
+        compinit -d ~/.cache/zsh/.zcompdump -C
+      '';
     };
+
     extraZshrc = {
       type = types.string;
       description = ''
-        zsh script to be injected at the end of the wrapped package's `.zshrc`.
-
-        Disjoint with the `zshrcFiles` option.
+        zsh script to be injected after the `zshrcFiles` option in the wrapped
+        package's `.zshrc`.
       '';
-      mutatorType = types.string;
-      mergeFunc = adios.lib.merge.strings.concatLines;
+      example = ''
+        # zoxide must be added at the end of the .zshrc so we use extraZshrc.
+        # https://github.com/ajeetdsouza/zoxide?tab=readme-ov-file#installation
+        eval "$(zoxide init zsh)"
+      '';
     };
+
     zshrcFiles = {
       type = types.listOf types.pathLike;
       description = ''
-        zsh files to be sourced in the wrapped package's `.zshrc` file.
-
-        Disjoint with the `zshrc` option.
+        zsh files to be sourced after the `zshrc` option in the wrapped package's `.zshrc` file.
       '';
       mutatorType = types.listOf types.pathLike;
       mergeFunc = adios.lib.merge.lists.concat;
     };
+
     extraZshrcFiles = {
       type = types.listOf types.pathLike;
       description = ''
         zsh files to be sourced at the end of the wrapped package's `.zshrc` file.
-
-        Disjoint with the `zshrc` option.:
       '';
       mutatorType = types.listOf types.pathLike;
       mergeFunc = adios.lib.merge.lists.concat;
     };
+
+    settings = {
+      type = types.attrsOf types.bool;
+      description = ''
+        Options to be enabled or disabled in the wrapped package's `.zshrc` file.
+
+        See the documentation for valid options:
+        https://zsh.sourceforge.io/Doc/Release/Options.html
+      '';
+      example = {
+        appendhistory = true;
+        sharehistory = true;
+        autocd = false;
+        beep = false;
+      };
+      mutatorType = types.attrsOf types.bool;
+      mergeFunc = adios.lib.merge.attrs.recursively;
+    };
+
+    variables = {
+      type = types.attrs;
+      description = ''
+        Environment variables to be defined in the wrapped package's `.zshrc` file.
+      '';
+      example = {
+        HISTFILE = "~/.histfile";
+        HISTSIZE = 5000;
+      };
+      mutatorType = types.attrs;
+      mergeFunc = adios.lib.merge.attrs.recursively;
+    };
+
+    aliases =
+      let
+        alias = types.attrsOf (
+          types.union [
+            types.string
+            (types.struct "global alias" {
+              global = types.bool;
+              command = types.string;
+            })
+          ]
+        );
+      in {
+        type = alias;
+        description = ''
+          Aliases to be defined in the wrapped package's `.zshrc` file. Aliases
+          can either be a string defining the command to be aliased, or a struct
+          where you can define the command and if the alias should be global.
+
+          See the documentation for valid options:
+          https://zsh.sourceforge.io/Intro/intro_8.html
+        '';
+        example = {
+          ls = "ls --color";
+          G = {
+            global = true;
+            command = "| grep";
+          };
+        };
+        mutatorType = alias;
+        mergeFunc = adios.lib.merge.attrs.recursively;
+      };
+
+    plugins =
+      let
+        plugin = types.listOf (
+          types.union [
+            types.derivation
+            (types.struct "plugin" {
+              package = types.derivation;
+              path = types.string;
+            })
+          ]
+        );
+      in {
+        type = plugin;
+        description = ''
+          Plugins to be appended to the wrapped package's `.zshrc`.
+
+          If a value is a derivation, it will be sourced as
+          `<derivation>/share/<derivation.pname>/<derivation.pname>.zsh` which
+          should be compatible with the majority of plugins. If this path is
+          incorrect then the value may be defined as an attrSet containing the
+          attrs `package` and `path` and will be sourced as `<package>/<path>`.
+        '';
+        example = ''
+          [
+            pkgs.zsh-autosuggestions
+            {
+              package = pkgs.nix-zsh-completions;
+              path = "share/zsh/plugins/nix/nix-zsh-completions.plugin.zsh";
+            }
+          ];
+        '';
+        mutatorType = plugin;
+        mergeFunc = adios.lib.merge.lists.concat;
+      };
 
     extraPackages = {
       type = types.listOf types.derivation;
       description = ''
         Runtime dependencies to be injected into the wrapped package's path.
       '';
-      mutatorType = types.listOf types.pathLike;
+      mutatorType = types.listOf types.derivation;
       mergeFunc = adios.lib.merge.lists.concat;
     };
 
@@ -71,42 +174,74 @@
     let
       inherit (inputs.nixpkgs.pkgs) writeText;
       inherit (inputs.nixpkgs.lib) makeBinPath;
-      inherit (builtins) concatStringsSep;
-      sourceFiles = files: (concatStringsSep "\n" (map (file: "source ${file}") files));
+      inherit (builtins) concatStringsSep attrNames;
+      optionalString = cond: string: if cond then string else "";
+      # Concatenates a list of strings so they're formatted properly for the .zshrc
+      concat = elems: (concatStringsSep "\n" elems) + "\n\n";
+      # Whether a .zshrc should be generated
+      shouldConfigure =
+        options ? zshrc
+        || options ? zshrcFile
+        || options ? plugins
+        || options ? settings
+        || options ? aliases
+        || options ? variables;
+      # Generates zsh sourcing all the files in a list
+      sourceFiles = files: concat (map (file: "source ${file}") files);
       zshrc =
-        if options ? zshrcFiles then
-          (sourceFiles options.zshrcFiles)
-          + (
-            if options ? extraZshrcFiles then
-              "\n" + (sourceFiles options.extraZshrcFiles)
-            else
-              ""
-          )
-        else if options ? zshrc then
-          options.zshrc
-          + (
-            if options ? extraZshrc then
-              "\n" + options.extraZshrc
-            else
-              ""
-          )
-        else
-          null;
+        let
+          zshrcFiles = optionalString (options ? zshrcFiles) (sourceFiles "${options.zshrcFiles}\n");
+          extraZshrcFiles = optionalString (options ? extraZshrcFiles) "${options.extraZshrcFiles}\n";
+          zshrcText = optionalString (options ? zshrc) "${options.zshrc}\n";
+          extraZshrcText = optionalString (options ? extraZshrc) "${options.extraZshrc}\n";
+          settings = optionalString (options ? settings) concat (
+            map (name: "${optionalString (!options.settings.${name}) "un"}setopt ${name}") (
+              attrNames options.settings
+            )
+          );
+          variables = optionalString (options ? variables) concat (
+            map (name: "${name}=${toString options.variables.${name}}") (attrNames options.variables)
+          );
+          aliases = optionalString (options ? aliases) concat (
+            map (
+              name:
+              let
+                value = options.aliases.${name};
+              in
+              if value ? global && value.global then
+                "alias -g ${name}='${value.command}'"
+              else
+                "alias ${name}='${value.command or value}'"
+            ) (attrNames options.aliases)
+          );
+          plugins = optionalString (options ? plugins) sourceFiles (
+            map (
+              plugin:
+              if plugin ? path then
+                "${plugin.package}/${plugin.path}"
+              else
+                "${plugin}/share/${plugin.pname}/${plugin.pname}.zsh"
+            ) options.plugins
+          );
+        in
+        zshrcFiles
+        + zshrcText
+        + variables
+        + aliases
+        + settings
+        + extraZshrcFiles
+        + extraZshrcText
+        + plugins;
     in
-    assert !(options ? zshrc && options ? zshrcFiles);
-    # extraZshrcFiles requires zshrcFiles to be set.
-    assert (if options ? extraZshrcFiles && !(options ? zshrcFiles) then false else true);
-    # extraZshrc requires zshrc to be set.
-    assert (if options ? extraZshrc && !(options ? zshrc) then false else true);
     inputs.mkWrapper {
       inherit (options) package;
       wrapperArgs =
         if options ? extraPackages then "--prefix PATH : ${makeBinPath options.extraPackages}" else null;
       symlinks = {
-        "$out/.zshrc" = if options ? zshrc || options ? zshrcFile then writeText ".zshrc" zshrc else null;
+        "$out/.zshrc" = if shouldConfigure then writeText ".zshrc" zshrc else null;
       };
       environment = {
-        ZDOTDIR = if options ? zshrc || options ? zshrcFile then "$out" else null;
+        ZDOTDIR = if shouldConfigure then "$out" else null;
       };
     };
 }


### PR DESCRIPTION
This is a massive commit which does a number of things:
1. Allows for `zshrc` and `zshrcFiles` to be used with each other
2. Allows usage of `extraZshrc` and `extraZshrcFiles` without setting their corresponding options
3. Adds options for configuring aliases, variables, `setopt` options, and plugins

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
