### PR TITLE
add check spelling job, bump checkout action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Check generated docs and formatting
+name: Check generated docs, formatting and typos
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5
 
       - name: Generate docs
         run: |
@@ -23,6 +23,7 @@ jobs:
 
       - name: Check that generated docs are the same
         run: diff temp.json docs/options.json
+
   check-formatting:
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +31,15 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5
 
       - name: Check that all modules are formatted properly
         run: nix-shell -p "callPackage ./dev/nixfmt.nix {}" --command "nixfmt --check ./modules"
+
+  check-typos:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Check spelling
+      uses: crate-ci/typos@v1.44.0

--- a/docs/installation-flakes.md
+++ b/docs/installation-flakes.md
@@ -76,4 +76,4 @@ outputs = inputs: {
 };
 ```
 
-Now that you've installed adios-wrappers, feel fre to move onto the [usage instructions](./usage.md).
+Now that you've installed adios-wrappers, feel free to move onto the [usage instructions](./usage.md).

--- a/docs/options.json
+++ b/docs/options.json
@@ -153,7 +153,7 @@
       "type": "listOf<pathLike>"
     },
     "interactiveShellInit": {
-      "description": "Shell initialization code to be automatically injected into the wrapped package. Only ran when Fish is initalized interactively.",
+      "description": "Shell initialization code to be automatically injected into the wrapped package. Only ran when Fish is initialized interactively.",
       "mutatorType": "string",
       "type": "string"
     },

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -84,7 +84,7 @@ lib.recursiveUpdate [
 As you can see, the right attrset "updates" the left attrset, with the right attrset taking priority if there's a key collision. This
 means we can take the existing modules and:
 
-- Inject our personal configuration wth `options.$OPTION_NAME.default`
+- Inject our personal configuration with `options.$OPTION_NAME.default`
 - Use computed defaults with `options.$OPTION_NAME.defaultFunc`
 - Specify mutators for an option with `options.$OPTION_NAME.mutators`
 - Add inputs to a module with `inputs.foo.path = "/foo";`

--- a/modules/fish.nix
+++ b/modules/fish.nix
@@ -141,7 +141,7 @@
       description = ''
         Shell initialization code to be automatically injected into the wrapped package.
 
-        Only ran when Fish is initalized interactively.
+        Only ran when Fish is initialized interactively.
       '';
       mutatorType = types.string;
       mergeFunc =

--- a/modules/swaybg.nix
+++ b/modules/swaybg.nix
@@ -49,7 +49,7 @@
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
-        # Unecessary as `backgroundImage` can be passed directly to `-i` but this assists with debugging.
+        # Unnecessary as `backgroundImage` can be passed directly to `-i` but this assists with debugging.
         "$out/backgroundImage" = if options ? backgroundImage then options.backgroundImage else null;
       };
       flags =


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned

[Test run](https://github.com/es-sai-fi/adios-wrappers/actions/runs/22596440733) i did.

There's the possibility of false positives but these can be handled through `_typos.toml`, you can take a look at the reference [here](https://github.com/crate-ci/typos/blob/master/docs/reference.md).