### PR TITLE
modules/swayidle: fix typo

### DIFF
--- a/modules/swayidle.nix
+++ b/modules/swayidle.nix
@@ -44,7 +44,7 @@
     let
       inherit (inputs.nixpkgs.pkgs) writeText;
       configFlag =
-        if options ? configContent || options ? configFile then
+        if options ? configContents || options ? configFile then
           [
             "-C"
             "$out/config"


### PR DESCRIPTION
## Checklist

- [ ] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
