### PR TITLE
modules: use verify functions instead of assertions

### DIFF
--- a/dev/_get-docs.nix
+++ b/dev/_get-docs.nix
@@ -9,6 +9,7 @@ mapAttrs (
     (removeAttrs option [
       "defaultFunc"
       "mergeFunc"
+      "verify"
     ])
     // {
       type = option.type.name;

--- a/docs/options.json
+++ b/docs/options.json
@@ -57,11 +57,11 @@
       "type": "pathLike"
     },
     "direnvrc": {
-      "description": "Custom direnvrc definition to be injected into the wrapped packages `direnvrc` The syntax is described at: https://direnv.net/#the-stdlib",
+      "description": "Custom direnvrc contents to be injected into the wrapped packages `direnvrc` The syntax is described at: https://direnv.net/#the-stdlib Disjoint with the `direnvrcFile` option.",
       "type": "string"
     },
     "direnvrcFile": {
-      "description": "`direnvrc` file to be copied into the wrapped package. The syntax is described at: https://direnv.net/#the-stdlib",
+      "description": "`direnvrc` file to be copied into the wrapped package. The syntax is described at: https://direnv.net/#the-stdlib Disjoint with the `direnvrc` option.",
       "type": "string"
     },
     "package": {
@@ -108,7 +108,7 @@
       "type": "derivation"
     },
     "themeFile": {
-      "description": "`theme.yml` file to be injected into the wrapped package. See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options Disjoint with the `themeConfig` option.",
+      "description": "`theme.yml` file to be injected into the wrapped package. See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options Disjoint with the `themes` option.",
       "type": "pathLike"
     },
     "themes": {
@@ -320,12 +320,12 @@
       "type": "attrs"
     },
     "theme": {
-      "description": "Theme name from `pkgs.kitty-themes` to be used. Each of the files in this folder constitute a valid theme: https://github.com/kovidgoyal/kitty-themes/tree/master/themes",
+      "description": "Theme name from `pkgs.kitty-themes` to be used. Each of the files in this folder constitute a valid theme: https://github.com/kovidgoyal/kitty-themes/tree/master/themes Disjoint with the `themeFile` option.",
       "example": "Catppuccin-Mocha",
       "type": "string"
     },
     "themeFile": {
-      "description": "Path containing a Kitty theme to be used.",
+      "description": "Path containing a Kitty theme to be used. Disjoint with the `theme` option.",
       "type": "pathLike"
     }
   },
@@ -412,7 +412,7 @@
 
   "nushell": {
     "configFile": {
-      "description": "`config.nu` file to be injected into the wrapped package. See the nushell documentation on file syntax: https://www.nushell.sh/book/configuration.html Disjoint with the `config` option.",
+      "description": "`config.nu` file to be injected into the wrapped package. See the nushell documentation on file syntax: https://www.nushell.sh/book/configuration.html Disjoint with the `shellInit` option.",
       "type": "pathLike"
     },
     "package": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,16 @@
   "nodes": {
     "adios": {
       "locked": {
-        "lastModified": 1773941032,
-        "narHash": "sha256-ksH0VV24EYsd87tig1IwBr4euDUHQT+hY6gaNs4HbIU=",
+        "lastModified": 1774374108,
+        "narHash": "sha256-utd+rlP+gEdX4H72PFn1mzpsJoIb0J4IPi9hlB4FIwo=",
         "owner": "llakala",
         "repo": "adios",
-        "rev": "e43e94daefb5e4a415b10f58bda1a6c05db1c902",
+        "rev": "401189e0c00f9789896cfa507016c2bc4a8b302c",
         "type": "github"
       },
       "original": {
         "owner": "llakala",
+        "ref": "verify-assertions",
         "repo": "adios",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
-  inputs.adios.url = "github:llakala/adios"; # My personal fork
+  # TODO: FIXME: point back to main when merging this
+  inputs.adios.url = "github:llakala/adios/verify-assertions"; # My personal fork
 
   outputs = inputs: {
     wrapperModules = import ./default.nix {

--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `alacritty.toml`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `alacritty.toml` file to be injected into the wrapped package.
 
@@ -41,7 +43,6 @@
     let
       generator = inputs.nixpkgs.pkgs.formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
       preSymlink = ''

--- a/modules/bat.nix
+++ b/modules/bat.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     flags = {
       type = types.listOf types.string;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Flags to be appended by default when running bat.
 
@@ -16,6 +17,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "flags" ];
       description = ''
         File containing the flags to be appended by default when running bat.
 
@@ -32,7 +34,6 @@
 
   impl =
     { options, inputs }:
-    assert !(options ? flags && options ? configFile);
     if options ? flags then
       inputs.mkWrapper {
         inherit (options) package flags;

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `bottom.toml`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `bottom.toml` file to be injected into the wrapped package.
 
@@ -41,7 +43,6 @@
     let
       generator = inputs.nixpkgs.pkgs.formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/btm";

--- a/modules/direnv.nix
+++ b/modules/direnv.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `direnv.toml`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `direnv.toml` file to be injected into the wrapped package.
 
@@ -30,20 +32,26 @@
     };
     direnvrc = {
       type = types.string;
+      verify = adios.lib.disjointWith [ "direnvrcFile" ];
       description = ''
-        Custom direnvrc definition to be injected into the wrapped packages `direnvrc`
+        Custom direnvrc contents to be injected into the wrapped packages `direnvrc`
 
         The syntax is described at:
         https://direnv.net/#the-stdlib
+
+        Disjoint with the `direnvrcFile` option.
       '';
     };
     direnvrcFile = {
       type = types.string;
+      verify = adios.lib.disjointWith [ "direnvrc" ];
       description = ''
         `direnvrc` file to be copied into the wrapped package.
 
         The syntax is described at:
         https://direnv.net/#the-stdlib
+
+        Disjoint with the `direnvrc` option.
       '';
     };
     package = {
@@ -103,8 +111,6 @@
 
   impl =
     { options, inputs }:
-    assert !(options ? settings && options ? configFile);
-    assert !(options ? direnvrc && options ? direnvrcFile);
     let
       inherit (inputs.nixpkgs.pkgs) formats writeText nix-direnv;
       generator = formats.toml {};

--- a/modules/discordo.nix
+++ b/modules/discordo.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's 'config.toml'.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `config.toml` file to be injected into the wrapped package.
 
@@ -59,7 +61,6 @@
     let
       generator = inputs.nixpkgs.pkgs.formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package flags;
       preSymlink = ''

--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -16,6 +16,7 @@
 
     themes = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "themeFile" ];
       description = ''
         Settings to be injected into the wrapped package's `theme.yml`.
 
@@ -26,12 +27,13 @@
     };
     themeFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "themes" ];
       description = ''
         `theme.yml` file to be injected into the wrapped package.
 
         See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options
 
-        Disjoint with the `themeConfig` option.
+        Disjoint with the `themes` option.
       '';
     };
 
@@ -48,7 +50,6 @@
       inherit (inputs.nixpkgs.pkgs) writeText;
       inherit (inputs.nixpkgs.lib.generators) toJSON;
     in
-    assert !(options ? themeConfig && options ? themeFile);
     inputs.mkWrapper {
       inherit (options) package flags;
       preSymlink = ''

--- a/modules/firefox.nix
+++ b/modules/firefox.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     nixpkgs.path = "/nixpkgs";
@@ -17,6 +17,7 @@
 
     policies = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "policiesFiles" ];
       description = ''
         Policies to be injected into the wrapped package.
 
@@ -27,6 +28,7 @@
     };
     policiesFiles = {
       type = types.listOf types.pathLike;
+      verify = adios.lib.disjointWith [ "policies" ];
       description = ''
         JSON files containing policies to be injected into the wrapped package.
 
@@ -65,7 +67,6 @@
       inherit (builtins) filter attrNames;
       filterNullAttrs = set: removeAttrs set (filter (name: isNull set.${name}) (attrNames set));
     in
-    assert !(options ? policies && options ? policiesFiles);
     wrapFirefox options.package (filterNullAttrs {
       extraPolicies = options.policies or null;
       # From my testing, these options need to be coerced to store paths.

--- a/modules/fish.nix
+++ b/modules/fish.nix
@@ -9,6 +9,7 @@
     # TODO: add mergeFunc for completions and functions options
     completions = {
       type = types.attrsOf types.string;
+      verify = adios.lib.disjointWith [ "completionsFiles" ];
       description = ''
         Custom completions to be injected into the wrapped package.
 
@@ -19,6 +20,7 @@
     };
     completionsFiles = {
       type = types.listOf types.pathLike;
+      verify = adios.lib.disjointWith [ "completions" ];
       description = ''
         Files containing custom completions to be injected into the wrapped package.
 
@@ -30,6 +32,7 @@
 
     functions = {
       type = types.attrsOf types.string;
+      verify = adios.lib.disjointWith [ "functionsFiles" ];
       description = ''
         Custom functions to be injected into the wrapped package.
 
@@ -40,6 +43,7 @@
     };
     functionsFiles = {
       type = types.listOf types.pathLike;
+      verify = adios.lib.disjointWith [ "functions" ];
       description = ''
         Files containing custom functions to be injected into the wrapped package.
 
@@ -169,8 +173,6 @@
       inherit (inputs.nixpkgs.pkgs) writeText;
       inherit (builtins) listToAttrs attrNames;
     in
-    assert !(options ? completions && options ? completionsFiles);
-    assert !(options ? functions && options ? functionsFiles);
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = (

--- a/modules/fuzzel.nix
+++ b/modules/fuzzel.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `fuzzel.ini`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `fuzzel.ini` file to be injected into the wrapped package.
 
@@ -86,17 +88,16 @@
     in
     assert (
       if options ? dmenuFlags then
-        (options ? settings || options ? configFile)
+        options ? settings || options ? configFile
       else
         true
     );
     assert (
       if options ? logFlags then
-        (options ? settings || options ? configFile)
+        options ? settings || options ? configFile
       else
         true
     );
-    assert !(options ? settings && options ? configFile);
     let
       dmenuFlags =
         if options ? dmenuFlags then

--- a/modules/gh.nix
+++ b/modules/gh.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configDir" ];
       description = ''
         Settings to be injected into the wrapped package's `config.yml`.
 
@@ -19,6 +20,7 @@
     };
     hosts = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configDir" ];
       description = ''
         Host information to be injected into the wrapped package's `hosts.yml`.
 
@@ -27,6 +29,10 @@
     };
     configDir = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [
+        "settings"
+        "hosts"
+      ];
       description = ''
         Folder containing gh configuration files to be injected into the wrapped package.
 
@@ -68,7 +74,6 @@
           value
       );
     in
-    assert !(options ? configDir && (options ? settings || options ? hosts));
     if options ? configDir then
       inputs.mkWrapper {
         inherit (options) package;

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `gitconfig`.
 
@@ -21,6 +22,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `gitconfig` file to be injected into the wrapped package.
 
@@ -36,6 +38,7 @@
 
     ignoredPaths = {
       type = types.listOf types.string;
+      verify = adios.lib.disjointWith [ "ignoreFile" ];
       description = ''
         Extra path globs to be ignored automatically, along with the repo-specific `.gitignore`.
 
@@ -44,6 +47,7 @@
     };
     ignoreFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "ignoredPaths" ];
       description = ''
         File containing extra path globs to be ignored automatically, along with the repo-specific `.gitignore`.
 
@@ -71,8 +75,6 @@
       inherit (inputs.nixpkgs.pkgs) writeText;
       inherit (inputs.nixpkgs.lib.generators) toGitINI;
     in
-    assert !(options ? settings && options ? configFile);
-    assert !(options ? ignoredPaths && options ? ignoreFile);
     inputs.mkWrapper {
       name = "git"; # Default derivation name is git-with-svn
       inherit (options) package;

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `config.toml`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `config.toml` file to be injected into the wrapped package.
 
@@ -31,6 +33,7 @@
 
     themes = {
       type = types.attrsOf types.attrs;
+      verify = adios.lib.disjointWith [ "themeDir" ];
       description = ''
         An attrset of custom themes, mapping the name of a theme to its settings.
 
@@ -42,6 +45,7 @@
     };
     themeDir = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "themes" ];
       description = ''
         Folder containing theme configuration files to be injected into the wrapped package.
 
@@ -53,6 +57,7 @@
 
     languages = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "languagesFile" ];
       description = ''
         Language config to be injected into the wrapped package's `languages.toml`.
 
@@ -64,6 +69,7 @@
     };
     languagesFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "languages" ];
       description = ''
         `languages.toml` file to be injected into the wrapped package.
 
@@ -110,9 +116,6 @@
         else
           {};
     in
-    assert !(options ? settings && options ? configFile);
-    assert !(options ? themes && options ? themeDir);
-    assert !(options ? languages && options ? languagesFile);
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/hx";

--- a/modules/jujutsu.nix
+++ b/modules/jujutsu.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `config.toml`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `config.toml` file to be injected into the wrapped package.
 
@@ -52,7 +54,6 @@
       inherit (inputs.nixpkgs.lib) makeBinPath;
       generator = formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/jj";

--- a/modules/kitty.nix
+++ b/modules/kitty.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `kitty.conf`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `kitty.conf` file to be injected into the wrapped package.
 
@@ -31,18 +33,24 @@
 
     theme = {
       type = types.string;
+      verify = adios.lib.disjointWith [ "themeFile" ];
       description = ''
         Theme name from `pkgs.kitty-themes` to be used.
 
         Each of the files in this folder constitute a valid theme:
         https://github.com/kovidgoyal/kitty-themes/tree/master/themes
+
+        Disjoint with the `themeFile` option.
       '';
       example = "Catppuccin-Mocha";
     };
     themeFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "theme" ];
       description = ''
         Path containing a Kitty theme to be used.
+
+        Disjoint with the `theme` option.
       '';
     };
 
@@ -85,8 +93,6 @@
         } " ";
       };
     in
-    assert !(options ? settings && options ? configFile);
-    assert !(options ? theme && options ? themeFile);
     inputs.mkWrapper {
       inherit (options) package;
       preSymlink = ''

--- a/modules/less.nix
+++ b/modules/less.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     flags = {
       type = types.listOf types.string;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Flags to be automatically appended when running less.
 
@@ -21,6 +22,7 @@
     # TODO: add rfc42 variants of the #command and #line-edit sections
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "flags" ];
       description = ''
         `lesskey` file to be injected into the wrapped package.
 
@@ -46,7 +48,6 @@
     let
       inherit (builtins) concatStringsSep;
     in
-    assert !(options ? flags && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
       environment = {

--- a/modules/nushell.nix
+++ b/modules/nushell.nix
@@ -8,6 +8,7 @@
   options = {
     shellInit = {
       type = types.string;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Shell initialisation code to be injected into the wrapped package's `config.nu`.
 
@@ -21,13 +22,14 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "shellInit" ];
       description = ''
         `config.nu` file to be injected into the wrapped package.
 
         See the nushell documentation on file syntax:
         https://www.nushell.sh/book/configuration.html
 
-        Disjoint with the `config` option.
+        Disjoint with the `shellInit` option.
       '';
     };
 

--- a/modules/ripgrep.nix
+++ b/modules/ripgrep.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     flags = {
       type = types.listOf types.string;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Flags to be automatically appended when running ripgrep.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "flags" ];
       description = ''
         `ripgreprc` file, containing flags to be automatically appended when running ripgrep.
 
@@ -41,7 +43,6 @@
 
   impl =
     { options, inputs }:
-    assert !(options ? flags && options ? configFile);
     if options ? flags then
       inputs.mkWrapper {
         name = "rg";

--- a/modules/starship.nix
+++ b/modules/starship.nix
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `starship.toml`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `starship.toml` file to be injected into the wrapped package.
 
@@ -45,18 +47,16 @@
           inherit (inputs.nixpkgs.lib) recursiveUpdate;
           inherit (adios.lib) merge;
           generator = inputs.nixpkgs.pkgs.formats.toml {};
-          default =
-            assert !(options ? settings && options ? configFile);
-            {
-              inherit (options) package;
-              environment.STARSHIP_CONFIG =
-                if options ? configFile then
-                  options.configFile
-                else if options ? settings then
-                  generator.generate "starship.toml" options.settings
-                else
-                  null;
-            };
+          default = {
+            inherit (options) package;
+            environment.STARSHIP_CONFIG =
+              if options ? configFile then
+                options.configFile
+              else if options ? settings then
+                generator.generate "starship.toml" options.settings
+              else
+                null;
+          };
         in
         # Allow mutators to change the default value, with the mutators taking
         # priority if the key is the same

--- a/modules/swayidle.nix
+++ b/modules/swayidle.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     configContents = {
       type = types.string;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `config` file.
 
@@ -18,6 +19,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "configContents" ];
       description = ''
         `config` file to be injected into the wrapped package.
 
@@ -60,7 +62,6 @@
         else
           [];
     in
-    assert !(options ? configContents && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {

--- a/modules/tealdeer.nix
+++ b/modules/tealdeer.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `config.toml`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `config.toml` file to be injected into the wrapped package.
 
@@ -41,7 +43,6 @@
     let
       generator = inputs.nixpkgs.pkgs.formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/tldr";

--- a/modules/termfilechooser.nix
+++ b/modules/termfilechooser.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's configuration file.
 
@@ -17,6 +18,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         Configuration file to be injected into the wrapped package.
 
@@ -37,7 +39,6 @@
     let
       generator = inputs.nixpkgs.pkgs.formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/libexec/xdg-desktop-portal-termfilechooser";

--- a/modules/waybar.nix
+++ b/modules/waybar.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Settings to be injected into the wrapped package's `config.jsonc`.
 
@@ -19,6 +20,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `config.jsonc` file to be injected into the wrapped package.
 
@@ -31,6 +33,7 @@
 
     barStyle = {
       type = types.string;
+      verify = adios.lib.disjointWith [ "cssFile" ];
       description = ''
         CSS to be injected into the wrapped package's `style.css`.
 
@@ -42,6 +45,7 @@
     };
     cssFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "barStyle" ];
       description = ''
         `style.css` file to be injected into the wrapped package.
 
@@ -79,8 +83,6 @@
       inherit (inputs.nixpkgs.pkgs) writeText;
       inherit (inputs.nixpkgs.lib.generators) toJSON;
     in
-    assert !(options ? settings && options ? configFile);
-    assert !(options ? barStyle && options ? cssFile);
     let
       configFlag =
         if options ? configFile then

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -8,6 +8,7 @@
   options = {
     settings = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "settingsFile" ];
       description = ''
         Settings to be injected into the wrapped package's `yazi.toml`.
 
@@ -19,6 +20,7 @@
     };
     settingsFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "settings" ];
       description = ''
         `yazi.toml` file to be injected into the wrapped package.
 
@@ -31,6 +33,7 @@
 
     keymap = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "keymapFile" ];
       description = ''
         Keybinds injected into the wrapped package's `keymap.toml`.
 
@@ -42,6 +45,7 @@
     };
     keymapFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "keymap" ];
       description = ''
         `keymap.toml` file to be injected into the wrapped package.
 
@@ -54,6 +58,7 @@
 
     theme = {
       type = types.attrs;
+      verify = adios.lib.disjointWith [ "themeFile" ];
       description = ''
         Theme settings to be injected into the wrapped package's `theme.toml`.
 
@@ -65,6 +70,7 @@
     };
     themeFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "theme" ];
       description = ''
         `theme.toml` file to be injected into the wrapped package.
 
@@ -77,6 +83,7 @@
 
     initLua = {
       type = types.string;
+      verify = adios.lib.disjointWith [ "initLuaFile" ];
       description = ''
         Lua script to be injected into the wrapped package's `init.lua`.
 
@@ -88,6 +95,7 @@
     };
     initLuaFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "initLua" ];
       description = ''
         `init.lua` file to be injected into the wrapped package.
 
@@ -161,9 +169,6 @@
       optionalAttrs = cond: attrs: if cond then attrs else {};
       generator = pkgs.formats.toml {};
     in
-    assert !(options ? settings && options ? settingsFile);
-    assert !(options ? keymap && options ? keymapFile);
-    assert !(options ? initLua && options ? initLuaFile);
     inputs.mkWrapper {
       inherit (options) package;
       preSymlink = ''

--- a/modules/zellij.nix
+++ b/modules/zellij.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.path = "/mkWrapper";
@@ -11,6 +11,7 @@
   options = {
     configContents = {
       type = types.string;
+      verify = adios.lib.disjointWith [ "configFile" ];
       description = ''
         Config to be injected into the wrapped package's `config.kdl`.
 
@@ -22,6 +23,7 @@
     };
     configFile = {
       type = types.pathLike;
+      verify = adios.lib.disjointWith [ "configContents" ];
       description = ''
         `config.kdl` file to be injected into the wrapped package.
 
@@ -34,6 +36,7 @@
 
     layoutsContents = {
       type = types.attrsOf types.string;
+      verify = adios.lib.disjointWith [ "layoutsFiles" ];
       description = ''
         Custom layouts to be injected into the wrapped package.
 
@@ -45,6 +48,7 @@
     };
     layoutsFiles = {
       type = types.listOf types.pathLike;
+      verify = adios.lib.disjointWith [ "layoutsContents" ];
       description = ''
         Files containing custom layouts to be injected into the wrapped package.
 
@@ -85,8 +89,6 @@
       inherit (inputs.nixpkgs.pkgs) writeText;
       optionalAttrs = cond: attrs: if cond then attrs else {};
     in
-    assert !(options ? configContents && options ? configFile);
-    assert !(options ? layoutsContents && options ? layoutsFiles);
     inputs.mkWrapper {
       inherit (options) package;
       preSymlink = ''


### PR DESCRIPTION
New adios feature! Would appreciate if people would review this for any mistakes I made in the conversions, and check if their wrappers still build with it.

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
