### PR TITLE
mangowc: fix error in creating flag

### DIFF
--- a/modules/mangowc.nix
+++ b/modules/mangowc.nix
@@ -66,7 +66,7 @@
       inherit (inputs.nixpkgs.lib.generators) toKeyValue;
       generator = attrs: writeText (toKeyValue {} attrs);
       configFlag =
-        if options ? configFile then
+        if options ? configFile || options ? settings then
           [
             "-c"
             "$out/mango/config.conf"


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [ ] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
