### PR TITLE
modules: add squawky as maintainer to several modules

### DIFF
--- a/modules/direnv.nix
+++ b/modules/direnv.nix
@@ -136,4 +136,8 @@
         XDG_CONFIG_HOME = "$out";
       };
     };
+
+  meta = {
+    maintainers = [ "squawky" ];
+  };
 }

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -148,4 +148,8 @@
         XDG_CONFIG_HOME = "$out";
       };
     };
+
+  meta = {
+    maintainers = [ "squawky" ];
+  };
 }

--- a/modules/mangowc.nix
+++ b/modules/mangowc.nix
@@ -106,4 +106,8 @@
       };
       flags = configFlag ++ autostartFlag;
     };
+
+  meta = {
+    maintainers = [ "squawky" ];
+  };
 }

--- a/modules/nushell.nix
+++ b/modules/nushell.nix
@@ -70,4 +70,8 @@
           []
       );
     };
+
+  meta = {
+    maintainers = [ "squawky" ];
+  };
 }


### PR DESCRIPTION
@Squawkykaka I'm adding you as a maintainer to all the modules that you added. Being a "maintainer" just means you're using the module and can speak for its functionality, and I'll ping you on PRs (CI coming for this eventually™). If you ever stop using a given module, removing your name from the maintainers is fine - I don't plan on being as strong as nixpkgs when it comes to maintenance.

I'll wait for your approval before merge. You can also add yourself to the maintainers of other modules that you use and want to keep functional.