### PR TITLE
modules: add poacher as maintainer to several modules

### DIFF
--- a/modules/discordo.nix
+++ b/modules/discordo.nix
@@ -86,4 +86,8 @@
             null;
       };
     };
+
+  meta = {
+    maintainers = [ "poacher" ];
+  };
 }

--- a/modules/irssi.nix
+++ b/modules/irssi.nix
@@ -104,4 +104,8 @@
       };
       flags = homeFlag ++ configFlag ++ autoconnectFlag ++ nicknameFlag ++ hostnameFlag;
     };
+
+  meta = {
+    maintainers = [ "poacher" ];
+  };
 }

--- a/modules/swaybg.nix
+++ b/modules/swaybg.nix
@@ -68,4 +68,8 @@
           options.outputName
         ]);
     };
+
+  meta = {
+    maintainers = [ "poacher" ];
+  };
 }

--- a/modules/swayidle.nix
+++ b/modules/swayidle.nix
@@ -74,4 +74,8 @@
       };
       flags = configFlag ++ styleFlag;
     };
+
+  meta = {
+    maintainers = [ "poacher" ];
+  };
 }

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -245,4 +245,8 @@
         ZDOTDIR = if shouldConfigure then "$out" else null;
       };
     };
+
+  meta = {
+    maintainers = [ "poacher" ];
+  };
 }


### PR DESCRIPTION
@poach3r  I'm adding you as a maintainer to all the modules that you added. Being a "maintainer" just means you're using the module and can speak for its functionality, and I'll ping you on PRs (CI coming for this eventually™). If you ever stop using a given module, removing your name from the maintainers is fine - I don't plan on being as strong as nixpkgs when it comes to maintenance.

I'll wait for your approval before merge. You can also add yourself to the maintainers of other modules that you use and want to keep functional.