### PR TITLE
modules: add mango as maintainer to several modules

### DIFF
--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -67,4 +67,8 @@
         EZA_CONFIG_HOME = "$out/eza-config";
       };
     };
+
+  meta = {
+    maintainers = [ "mango" ];
+  };
 }

--- a/modules/fuzzel.nix
+++ b/modules/fuzzel.nix
@@ -139,4 +139,8 @@
         else
           "";
     };
+
+  meta = {
+    maintainers = [ "mango" ];
+  };
 }

--- a/modules/waybar.nix
+++ b/modules/waybar.nix
@@ -103,4 +103,8 @@
         GTK_DEBUG = if (options.interactiveEnv or false) then "interactive" else null;
       };
     };
+
+  meta = {
+    maintainers = [ "mango" ];
+  };
 }


### PR DESCRIPTION
@aabush64 I'm adding you as a maintainer to all the modules that you added. Being a "maintainer" just means you're using the module and can speak for its functionality, and I'll ping you on PRs (CI coming for this eventually™). If you ever stop using a given module, removing your name from the maintainers is fine - I don't plan on being as strong as nixpkgs when it comes to maintenance.

I'll wait for your approval before merge. You can also add yourself to the maintainers of other modules that you use and want to keep functional.