### PR TITLE
remove preSymlink

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -433,12 +433,6 @@
       "description": "Commands to be run after the wrapping process in the build steps.",
       "type": "union<null,string>"
     },
-    "preSymlink": {
-      "default": null,
-      "description": "Commands to be run before the symlinking process in the build steps. Commonly used to create a directory in which the symlinks will be placed.",
-      "example": "mkdir -p $out/foo-config",
-      "type": "union<null,string>"
-    },
     "preWrap": {
       "default": null,
       "description": "Commands to be run before the wrapping process in the build steps.",

--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -44,9 +44,6 @@
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
-      preSymlink = ''
-        mkdir -p $out/alacritty
-      '';
       symlinks = {
         "$out/alacritty/alacritty.toml" =
           if options ? configFile then

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -45,9 +45,6 @@
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/btm";
-      preSymlink = ''
-        mkdir -p $out/bottom
-      '';
       symlinks = {
         "$out/bottom/bottom.toml" =
           if options ? configFile then

--- a/modules/direnv.nix
+++ b/modules/direnv.nix
@@ -111,9 +111,6 @@
     assert !(options ? direnvrc && options ? direnvrcFile);
     inputs.mkWrapper {
       inherit (options) package;
-      preSymlink = ''
-        mkdir -p $out/direnv/lib
-      '';
       symlinks = {
         "$out/direnv/direnv.toml" =
           if options ? configFile then

--- a/modules/discordo.nix
+++ b/modules/discordo.nix
@@ -62,9 +62,6 @@
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package flags;
-      preSymlink = ''
-        mkdir -p $out/discordo/
-      '';
       environment = {
         XDG_CONFIG_HOME = "$out";
         DISCORDO_TOKEN =

--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -51,9 +51,6 @@
     assert !(options ? themeConfig && options ? themeFile);
     inputs.mkWrapper {
       inherit (options) package flags;
-      preSymlink = ''
-        mkdir -p $out/eza-config
-      '';
       symlinks = {
         "$out/eza-config/theme.yml" =
           if options ? themeFile then

--- a/modules/gh.nix
+++ b/modules/gh.nix
@@ -79,9 +79,6 @@
     else
       inputs.mkWrapper {
         inherit (options) package;
-        preSymlink = ''
-          mkdir -p $out/gh
-        '';
         symlinks = {
           "$out/gh/config.yml" =
             if options ? settings then

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -76,9 +76,6 @@
     inputs.mkWrapper {
       name = "git"; # Default derivation name is git-with-svn
       inherit (options) package;
-      preSymlink = ''
-        mkdir -p $out/git
-      '';
       symlinks = {
         "$out/git/config" =
           if options ? configFile then

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -116,9 +116,6 @@
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/hx";
-      preSymlink = ''
-        mkdir -p $out/helix/themes
-      '';
       symlinks = {
         "$out/helix/config.toml" =
           if options ? configFile then

--- a/modules/irssi.nix
+++ b/modules/irssi.nix
@@ -95,9 +95,6 @@
     inputs.mkWrapper {
       name = "irssi";
       inherit (options) package;
-      preSymlink = ''
-        mkdir -p $out/irssi
-      '';
       symlinks = {
         "$out/irssi/config" = if options ? config then writeText "config" options.config else null;
         "$out/irssi" = options.configDir or null;

--- a/modules/jujutsu.nix
+++ b/modules/jujutsu.nix
@@ -56,9 +56,6 @@
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/jj";
-      preSymlink = ''
-        mkdir -p $out/jj-config
-      '';
       symlinks = {
         "$out/jj-config/config.toml" =
           if options ? configFile then

--- a/modules/kitty.nix
+++ b/modules/kitty.nix
@@ -89,9 +89,6 @@
     assert !(options ? theme && options ? themeFile);
     inputs.mkWrapper {
       inherit (options) package;
-      preSymlink = ''
-        mkdir -p $out/kitty
-      '';
       symlinks = {
         "$out/kitty/kitty.conf" =
           if options ? configFile then

--- a/modules/mangowc.nix
+++ b/modules/mangowc.nix
@@ -85,9 +85,6 @@
     inputs.mkWrapper {
       inherit (options) package;
       name = "mango";
-      preSymlink = ''
-        mkdir -p $out/mango
-      '';
       symlinks = {
         "$out/mango/config.conf" =
           if options ? configFile then

--- a/modules/mkWrapper/default.nix
+++ b/modules/mkWrapper/default.nix
@@ -35,17 +35,6 @@ in {
       description = "Path within the input derivation to the binary which should be wrapped";
       defaultFunc = { options }: "$out/bin/${options.name}";
     };
-
-    preSymlink = {
-      type = nullOr types.string;
-      description = ''
-        Commands to be run before the symlinking process in the build steps. Commonly used to create a directory in which the symlinks will be placed.
-      '';
-      default = null;
-      example = ''
-        mkdir -p $out/foo-config
-      '';
-    };
     preWrap = {
       type = nullOr types.string;
       description = "Commands to be run before the wrapping process in the build steps.";
@@ -56,7 +45,6 @@ in {
       description = "Commands to be run after the wrapping process in the build steps.";
       default = null;
     };
-
     wrapperArgs = {
       type = nullOr types.string;
       description = "Extra args passed directly to wrapProgram.";
@@ -128,7 +116,10 @@ in {
           if destination == null then
             []
           else
-            [ "ln -s ${destination} ${symlink}" ]
+            [
+              "mkdir -p $(dirname ${symlink})"
+              "ln -s ${destination} ${symlink}"
+            ]
         ) (attrNames options.symlinks)
       );
       flagsStr = concatStringsSep " " (map (flag: "--add-flag \"${flag}\"") options.flags);
@@ -154,7 +145,6 @@ in {
         for i in $(cat $pathsPath); do
           ${lndir}/bin/lndir -silent $i $out
         done
-        ${ifNotNull options.preSymlink}
         ${symlinkedStr}
         ${ifNotNull options.preWrap}
         ${

--- a/modules/nushell.nix
+++ b/modules/nushell.nix
@@ -69,9 +69,6 @@
       inherit (options) package;
       wrapperArgs =
         if options ? extraPackages then "--prefix PATH : ${makeBinPath options.extraPackages}" else null;
-      preSymlink = ''
-        mkdir -p $out/nushell
-      '';
       symlinks = {
         "$out/nushell/config.nu" = writeText "config.nu" assembledConfig;
       };

--- a/modules/tealdeer.nix
+++ b/modules/tealdeer.nix
@@ -45,9 +45,6 @@
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/bin/tldr";
-      preSymlink = ''
-        mkdir -p $out/tealdeer-config
-      '';
       symlinks = {
         "$out/tealdeer-config/config.toml" =
           if options ? configFile then

--- a/modules/termfilechooser.nix
+++ b/modules/termfilechooser.nix
@@ -41,9 +41,6 @@
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/libexec/xdg-desktop-portal-termfilechooser";
-      preSymlink = ''
-        mkdir -p $out/xdg-desktop-portal-termfilechooser
-      '';
       symlinks = {
         "$out/xdg-desktop-portal-termfilechooser/config" =
           if options ? configFile then

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -166,10 +166,6 @@
     assert !(options ? initLua && options ? initLuaFile);
     inputs.mkWrapper {
       inherit (options) package;
-      preSymlink = ''
-        mkdir -p $out/yazi/plugins
-        mkdir -p $out/yazi/flavors
-      '';
       symlinks = {
         "$out/yazi/yazi.toml" =
           if options ? settingsFile then

--- a/modules/zellij.nix
+++ b/modules/zellij.nix
@@ -89,10 +89,6 @@
     assert !(options ? layoutsContents && options ? layoutsFiles);
     inputs.mkWrapper {
       inherit (options) package;
-      preSymlink = ''
-        mkdir -p $out/zellij-config/themes
-        mkdir -p $out/zellij-config/layouts
-      '';
       symlinks = {
         "$out/zellij-config/config.kdl" =
           if options ? configFile then


### PR DESCRIPTION
This pr removes preSymlink and replaces it with a little piece of bash code to create the directory each time something is symlinked.

This is not the best in terms of keeping derivations clean but its pretty good

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned
