### PR TITLE
modules/noctalia-shell: init

### DIFF
--- a/modules/matugen.nix
+++ b/modules/matugen.nix
@@ -1,0 +1,63 @@
+{ types, ... }:
+{
+  inputs = {
+    mkWrapper.path = "/mkWrapper";
+    nixpkgs.path = "/nixpkgs";
+  };
+
+  options = {
+    settings = {
+      type = types.attrs;
+      description = ''
+        Settings to be injected into the wrapped package's `config.toml`.
+
+        See the matugen docs for valid options:
+        https://iniox.github.io/#matugen/configuration
+
+        Disjoint with the `configFile` option.
+      '';
+    };
+    configFile = {
+      type = types.pathLike;
+      description = ''
+        `config.toml` file to be injected into the wrapped package.
+
+        See the matugen docs for valid options:
+        https://iniox.github.io/#matugen/configuration
+
+        Disjoint with the `settings` option.
+      '';
+    };
+    package = {
+      type = types.derivation;
+      description = "The matugen package to be wrapped.";
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.matugen;
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      generator = inputs.nixpkgs.pkgs.formats.toml {};
+    in
+    assert !(options ? configFile && options ? settings);
+    inputs.mkWrapper {
+      inherit (options) package;
+      preSymlink = ''
+        mkdir -p $out/matugen
+      '';
+      symlinks = {
+        "$out/matugen/config.toml" =
+          if options ? configFile then
+            options.configFile
+          else if options ? settings then
+            generator.generate "config.toml" options.settings
+          else
+            null;
+      };
+      flags = [
+        "-c"
+        "$out/matugen/config.toml"
+      ];
+    };
+}

--- a/modules/noctalia-shell.nix
+++ b/modules/noctalia-shell.nix
@@ -1,0 +1,65 @@
+{ types, ... }:
+{
+  inputs = {
+    mkWrapper.path = "/mkWrapper";
+    nixpkgs.path = "/nixpkgs";
+  };
+
+  options = {
+    settings = {
+      type = types.attrs;
+      description = ''
+        Settings to be injected into the wrapped package's `config.toml`.
+
+        See the noctalia docs for valid options:
+        https://docs.noctalia.dev/v5
+
+        Disjoint with the `configFile` option.
+      '';
+    };
+    configFile = {
+      type = types.pathLike;
+      description = ''
+        `config.toml` file to be injected into the wrapped package.
+
+        See the noctalia docs for valid options:
+        https://docs.noctalia.dev/v5
+
+        Disjoint with the `settings` option.
+      '';
+    };
+    package = {
+      type = types.derivation;
+      description = "The noctalia package to be wrapped.";
+      defaultFunc =
+        { inputs }:
+        inputs.nixpkgs.warn "adios-wrappers: noctalia-shell from nixpkgs is outdated and cannot be wrapped." inputs.nixpkgs.pkgs.noctalia-shell;
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      generator = inputs.nixpkgs.pkgs.formats.toml {};
+    in
+    assert !(options ? settings && options ? configFile);
+    inputs.mkWrapper {
+      name = "noctalia";
+      inherit (options) package;
+      preSymlink = ''
+        mkdir -p $out/noctalia
+      '';
+      symlinks = {
+        "$out/noctalia/noctalia.toml" =
+          if options ? configFile then
+            options.configFile
+          else if options ? settings then
+            generator.generate options.settings
+          else
+            null;
+      };
+      environment = {
+        NOCTALIA_CONFIG_HOME = "$out";
+      };
+    };
+}


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned
  - [x] settings variant
  - [ ] path variant

Noctalia is in a transition period to a new config format, and the one in nixpkgs uses an outdated format, so I added a warning to the default package spec. 
I marked this pr as a draft in case we want to wait for the newer format to reach nixpkgs, which might take a while.