### PR TITLE
modules/eza: Fix theme attribute injection thingy

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -107,13 +107,13 @@
       "description": "The eza package to be wrapped.",
       "type": "derivation"
     },
+    "theme": {
+      "description": "Settings to be injected into the wrapped package's `theme.yml`. See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options Disjoint with the `themeFile` option.",
+      "type": "attrs"
+    },
     "themeFile": {
       "description": "`theme.yml` file to be injected into the wrapped package. See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options Disjoint with the `themeConfig` option.",
       "type": "pathLike"
-    },
-    "themes": {
-      "description": "Settings to be injected into the wrapped package's `theme.yml`. See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options Disjoint with the `themeFile` option.",
-      "type": "attrs"
     }
   },
 

--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -14,7 +14,7 @@
       '';
     };
 
-    themes = {
+    theme = {
       type = types.attrs;
       description = ''
         Settings to be injected into the wrapped package's `theme.yml`.
@@ -48,15 +48,15 @@
       inherit (inputs.nixpkgs.pkgs) formats;
       generator = formats.json {};
     in
-    assert !(options ? themeConfig && options ? themeFile);
+    assert !(options ? theme && options ? themeFile);
     inputs.mkWrapper {
       inherit (options) package flags;
       symlinks = {
         "$out/eza-config/theme.yml" =
           if options ? themeFile then
             options.themeFile
-          else if options ? themeConfig then
-            generator.generate "theme.yml" options.themeConfig
+          else if options ? theme then
+            generator.generate "theme.yml" options.theme
           else
             null;
       };


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned

Just fixes themeConfig discrepancy, now just referenced as theme given other established nomenclature.