### PR TITLE
modules: use new `from` semantics

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,8 +21,8 @@ Here's an example module that adds both:
 { types, ... }:
 {
   inputs = {
-    nixpkgs.path = "/nixpkgs";
-    mkWrapper.path = "/mkWrapper";
+    nixpkgs.from = { parent }: parent.nixpkgs;
+    mkWrapper.from = { parent }: parent.mkWrapper;
   };
 
   options = {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,7 +86,7 @@ means we can take the existing modules and:
 - Inject our personal configuration with `options.$OPTION_NAME.default`
 - Use computed defaults with `options.$OPTION_NAME.defaultFunc`
 - Specify mutators for an option with `options.$OPTION_NAME.mutators`
-- Add inputs to a module with `inputs.foo.path = "/foo";`
+- Add inputs to a module with `inputs.foo.from = { parent }: parent.foo;`
 
 To use this method, replace the first TODO comment in `wrappers/default.nix`, embedding your config here:
 ```nix
@@ -98,7 +98,7 @@ overrides = {
     options.flags.default = [ "--quit-if-one-screen" ];
   };
   git = {
-    inputs.less.path = "/less";
+    inputs.less.from = { parent }: parent.less;
     options.settings.defaultFunc =
       { options, inputs }:
       {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "adios": {
       "locked": {
-        "lastModified": 1780268595,
-        "narHash": "sha256-NEci/9IYVJIxhfHG7v/5F1pAi6OaKRc2b3NFCm44DCM=",
+        "lastModified": 1781004957,
+        "narHash": "sha256-cHklMW166oywA7rOZZAljlIVuhfP4U6HXBcOn8BEi7k=",
         "owner": "llakala",
         "repo": "adios",
-        "rev": "2c4e879d4996056cffd558c283d7ed8b43c862ce",
+        "rev": "f48148c92ab838e4be5ff3b7a5e0600d5b4a0781",
         "type": "github"
       },
       "original": {

--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/bat.nix
+++ b/modules/bat.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/diff-so-fancy.nix
+++ b/modules/diff-so-fancy.nix
@@ -1,9 +1,9 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
-    git.path = "/git";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
+    git.from = { parent }: parent.git;
   };
 
   options = {

--- a/modules/direnv.nix
+++ b/modules/direnv.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/discordo.nix
+++ b/modules/discordo.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/firefox.nix
+++ b/modules/firefox.nix
@@ -1,7 +1,7 @@
 { types, ... }:
 {
   inputs = {
-    nixpkgs.path = "/nixpkgs";
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/fish.nix
+++ b/modules/fish.nix
@@ -1,8 +1,8 @@
 { types, ... } @ adios:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/fuzzel.nix
+++ b/modules/fuzzel.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/gh.nix
+++ b/modules/gh.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -1,8 +1,8 @@
 { types, ... } @ adios:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/irssi.nix
+++ b/modules/irssi.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/jujutsu.nix
+++ b/modules/jujutsu.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/kitty.nix
+++ b/modules/kitty.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/less.nix
+++ b/modules/less.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/mangowc.nix
+++ b/modules/mangowc.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/mkWrapper/builder.sh
+++ b/modules/mkWrapper/builder.sh
@@ -1,0 +1,5 @@
+@preSymlink@
+@symlink@
+@preWrap@
+wrapProgram @binaryPath@ @environment@ @flags@ @wrapperArgs@
+@postWrap@

--- a/modules/mkWrapper/default.nix
+++ b/modules/mkWrapper/default.nix
@@ -8,7 +8,7 @@ let
     ];
 in {
   inputs = {
-    nixpkgs.path = "/nixpkgs";
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/nushell.nix
+++ b/modules/nushell.nix
@@ -1,8 +1,8 @@
 { types, ... } @ adios:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/ripgrep.nix
+++ b/modules/ripgrep.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/starship.nix
+++ b/modules/starship.nix
@@ -1,8 +1,8 @@
 { types, ... } @ adios:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/swaybg.nix
+++ b/modules/swaybg.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/swayidle.nix
+++ b/modules/swayidle.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/tealdeer.nix
+++ b/modules/tealdeer.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/termfilechooser.nix
+++ b/modules/termfilechooser.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/waybar.nix
+++ b/modules/waybar.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/zellij.nix
+++ b/modules/zellij.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   # The reason for there not being RFC42 options like `settings` or `layouts` is

--- a/modules/zoxide.nix
+++ b/modules/zoxide.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -1,8 +1,8 @@
 { types, ... } @ adios:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {


### PR DESCRIPTION
Going with the new adios changes.
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
