### PR TITLE
modules: use `from` for missed modules

### DIFF
--- a/modules/btop.nix
+++ b/modules/btop.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/fastfetch.nix
+++ b/modules/fastfetch.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/hyfetch.nix
+++ b/modules/hyfetch.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {

--- a/modules/mpv.nix
+++ b/modules/mpv.nix
@@ -1,8 +1,8 @@
 { types, ... }:
 {
   inputs = {
-    mkWrapper.path = "/mkWrapper";
-    nixpkgs.path = "/nixpkgs";
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
   };
 
   options = {


### PR DESCRIPTION
Some modules that were missed in #58

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
