### PR TITLE
modules/wiremix: init

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -817,6 +817,21 @@
     }
   },
 
+  "wiremix": {
+    "configFile": {
+      "description": "`wiremix.toml` file to be injected into the wrapped package. See the documentation for syntax and valid options: https://github.com/tsowell/wiremix/blob/main/wiremix.toml Disjoint with the `settings` option.",
+      "type": "pathLike"
+    },
+    "package": {
+      "description": "The wiremix package to be wrapped.",
+      "type": "derivation"
+    },
+    "settings": {
+      "description": "Settings to be injected into the wrapped package's `wiremix.toml`. See the documentation for syntax and valid options: https://github.com/tsowell/wiremix/blob/main/wiremix.toml Disjoint with the `configFile` option.",
+      "type": "attrs"
+    }
+  },
+
   "yazi": {
     "extraPackages": {
       "description": "Packages to be automatically added as Yazi dependencies. This defaults to the optionalDeps of the Yazi package in nixpkgs, set here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ya/yazi/package.nix#L8 The dependency `File` is added regardless of the content of this option, because it's non-optional. See the Yazi docs on this topic: https://yazi-rs.github.io/docs/installation",

--- a/modules/wiremix.nix
+++ b/modules/wiremix.nix
@@ -1,0 +1,61 @@
+{ types, ... }: {
+  inputs = {
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
+  };
+
+  options = {
+    settings = {
+      type = types.attrs;
+      description = ''
+        Settings to be injected into the wrapped package's `wiremix.toml`.
+
+        See the documentation for syntax and valid options:
+        https://github.com/tsowell/wiremix/blob/main/wiremix.toml
+
+        Disjoint with the `configFile` option.
+      '';
+    };
+    configFile = {
+      type = types.pathLike;
+      description = ''
+        `wiremix.toml` file to be injected into the wrapped package.
+
+        See the documentation for syntax and valid options:
+        https://github.com/tsowell/wiremix/blob/main/wiremix.toml
+
+        Disjoint with the `settings` option.
+      '';
+    };
+
+    package = {
+      type = types.derivation;
+      description = "The wiremix package to be wrapped.";
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.wiremix;
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      inherit (inputs.nixpkgs) pkgs;
+      inherit (inputs.nixpkgs.pkgs) writeText;
+      generator = pkgs.formats.toml {};
+    in
+    assert !(options ? settings && options ? configFile);
+    inputs.mkWrapper {
+      inherit (options) package;
+      symlinks = {
+        "$out/wiremix/wiremix.toml" =
+          if options ? configFile then
+            options.configFile
+          else if options ? settings then
+            generator.generate "wiremix.toml" options.settings
+          else
+            null;
+      };
+      environment = {
+        XDG_CONFIG_HOME = "$out";
+      };
+    };
+}


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned




`FRIDT24THM`