### PR TITLE
modules/eza: Fix option naming and environment variables

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -141,13 +141,13 @@
       "description": "The eza package to be wrapped.",
       "type": "derivation"
     },
-    "themeFile": {
-      "description": "`theme.yml` file to be injected into the wrapped package. See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options Disjoint with the `themeConfig` option.",
-      "type": "pathLike"
-    },
-    "themes": {
+    "theme": {
       "description": "Settings to be injected into the wrapped package's `theme.yml`. See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options Disjoint with the `themeFile` option.",
       "type": "attrs"
+    },
+    "themeFile": {
+      "description": "`theme.yml` file to be injected into the wrapped package. See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options Disjoint with the `theme` option.",
+      "type": "pathLike"
     }
   },
 

--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -14,7 +14,7 @@
       '';
     };
 
-    themes = {
+    theme = {
       type = types.attrs;
       description = ''
         Settings to be injected into the wrapped package's `theme.yml`.
@@ -31,7 +31,7 @@
 
         See `https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md` for valid options
 
-        Disjoint with the `themeConfig` option.
+        Disjoint with the `theme` option.
       '';
     };
 
@@ -48,20 +48,20 @@
       inherit (inputs.nixpkgs.pkgs) formats;
       generator = formats.json {};
     in
-    assert !(options ? themeConfig && options ? themeFile);
+    assert !(options ? theme && options ? themeFile);
     inputs.mkWrapper {
       inherit (options) package flags;
       symlinks = {
         "$out/eza-config/theme.yml" =
           if options ? themeFile then
             options.themeFile
-          else if options ? themeConfig then
-            generator.generate "theme.yml" options.themeConfig
+          else if options ? theme then
+            generator.generate "theme.yml" options.theme
           else
             null;
       };
       environment = {
-        EZA_CONFIG_HOME = "$out/eza-config";
+        EZA_CONFIG_DIR = "$out/eza-config";
       };
     };
 


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned