### PR TITLE
modules/fastfetch: hard code name for unwrapped

### DIFF
--- a/modules/fastfetch.nix
+++ b/modules/fastfetch.nix
@@ -45,6 +45,7 @@
     in
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
+      name = "fastfetch"; # Needs to be hard coded for users of fastfetch-unwrapped
       inherit (options) package;
       symlinks = {
         "$out/fastfetch/config.jsonc" =


### PR DESCRIPTION
fastfetch in nixpkgs has split out a unwrapped variant which is broken without this

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
