### PR TITLE
modules: distinguish binary and drv name for `mkWrapper`

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -570,13 +570,13 @@
       "description": "Flags to be automatically appended to the wrapped program.",
       "type": "listOf<string>"
     },
-    "name": {
-      "description": "The name of the package to be wrapped. This determines the pname of the wrapped package.",
-      "type": "string"
-    },
     "package": {
       "description": "The package to be wrapped.",
       "type": "derivation"
+    },
+    "pname": {
+      "description": "The name of the package to be wrapped.",
+      "type": "string"
     },
     "postWrap": {
       "default": null,

--- a/docs/options.json
+++ b/docs/options.json
@@ -547,8 +547,12 @@
   },
 
   "mkWrapper": {
+    "binaryName": {
+      "description": "The name of the binary to be wrapped. This sets the `meta.mainProgram` of the wrapped package, and the default `binaryPath` to wrap with.",
+      "type": "string"
+    },
     "binaryPath": {
-      "description": "Path within the input derivation to the binary which should be wrapped.",
+      "description": "The path of the binary within the input derivation to be wrapped. This should only be set if the binary isn't inside $out/bin. If it is, `binaryName` can be used instead.",
       "type": "string"
     },
     "environment": {
@@ -567,7 +571,7 @@
       "type": "listOf<string>"
     },
     "name": {
-      "description": "The name of the package to be wrapped. This determines the pname of the wrapped package, as well as the derivation to be automatically run when using `nix run`.",
+      "description": "The name of the package to be wrapped. This determines the pname of the wrapped package.",
       "type": "string"
     },
     "package": {

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -45,7 +45,6 @@
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
-      binaryPath = "$out/bin/btm";
       symlinks = {
         "$out/bottom/bottom.toml" =
           if options ? configFile then

--- a/modules/fastfetch.nix
+++ b/modules/fastfetch.nix
@@ -45,7 +45,6 @@
     in
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
-      name = "fastfetch"; # Needs to be hard coded for users of fastfetch-unwrapped
       inherit (options) package;
       symlinks = {
         "$out/fastfetch/config.jsonc" =

--- a/modules/fuzzel.nix
+++ b/modules/fuzzel.nix
@@ -128,7 +128,6 @@
     );
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
-      name = "fuzzel";
       inherit (options) package;
       inherit flags;
       preWrap =

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -74,7 +74,6 @@
     assert !(options ? settings && options ? configFile);
     assert !(options ? ignoredPaths && options ? ignoreFile);
     inputs.mkWrapper {
-      name = "git"; # Default derivation name is git-with-svn
       inherit (options) package;
       symlinks = {
         "$out/git/config" =

--- a/modules/gnupg.nix
+++ b/modules/gnupg.nix
@@ -51,7 +51,6 @@
     in
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
-      name = "gpg";
       inherit (options) package;
       symlinks = {
         "$out/gnupg/gpg.conf" =

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -115,7 +115,6 @@
     assert !(options ? languages && options ? languagesFile);
     inputs.mkWrapper {
       inherit (options) package;
-      binaryPath = "$out/bin/hx";
       symlinks = {
         "$out/helix/config.toml" =
           if options ? configFile then

--- a/modules/hydrus.nix
+++ b/modules/hydrus.nix
@@ -47,7 +47,7 @@
     in
     inputs.mkWrapper {
       inherit (options) package;
-      binaryPath = "$out/bin/hydrus-client";
+      binaryName = "hydrus-client";
       flags = if options ? clientFlags then options.clientFlags else [];
       postWrap =
         if options ? serverFlags then

--- a/modules/irssi.nix
+++ b/modules/irssi.nix
@@ -86,7 +86,6 @@
     in
     assert !(options ? configDir && options ? config);
     inputs.mkWrapper {
-      name = "irssi";
       inherit (options) package;
       symlinks = {
         "$out/irssi/config" = if options ? config then writeText "config" options.config else null;

--- a/modules/jujutsu.nix
+++ b/modules/jujutsu.nix
@@ -55,7 +55,6 @@
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
-      binaryPath = "$out/bin/jj";
       symlinks = {
         "$out/jj-config/config.toml" =
           if options ? configFile then

--- a/modules/mangowc.nix
+++ b/modules/mangowc.nix
@@ -85,7 +85,6 @@
     assert !(options ? autostartContents && options ? autostartFile);
     inputs.mkWrapper {
       inherit (options) package;
-      name = "mango";
       symlinks = {
         "$out/mango/config.conf" =
           if options ? configFile then

--- a/modules/mkWrapper/default.nix
+++ b/modules/mkWrapper/default.nix
@@ -17,7 +17,7 @@ in {
       description = ''
         The name of the package to be wrapped.
 
-        This determines the pname of the wrapped package, as well as the derivation to be automatically run when using `nix run`.
+        This determines the pname of the wrapped package.
       '';
     };
     extraPaths = {
@@ -25,10 +25,23 @@ in {
       description = "Extra derivations which should have their directory structures replicated in the final package.";
       default = [];
     };
+    binaryName = {
+      type = types.string;
+      description = ''
+        The name of the binary to be wrapped.
+
+        This sets the `meta.mainProgram` of the wrapped package, and the default `binaryPath` to wrap with.
+      '';
+      defaultFunc = { options }: options.package.meta.mainProgram or options.name;
+    };
     binaryPath = {
       type = types.string;
-      defaultFunc = { options }: "$out/bin/${options.name}";
-      description = "Path within the input derivation to the binary which should be wrapped.";
+      defaultFunc = { options }: "$out/bin/${options.binaryName}";
+      description = ''
+        The path of the binary within the input derivation to be wrapped.
+
+        This should only be set if the binary isn't inside $out/bin. If it is, `binaryName` can be used instead.
+      '';
     };
     preWrap = {
       type = nullOrString;
@@ -127,7 +140,7 @@ in {
           [ "${options.package}" ]
         else
           map (path: "${path}") ([ options.package ] ++ options.extraPaths);
-      meta.mainProgram = options.name;
+      meta.mainProgram = options.binaryName;
       passthru = options.package.passthru or {};
 
       preferLocalBuild = true;

--- a/modules/mkWrapper/default.nix
+++ b/modules/mkWrapper/default.nix
@@ -11,13 +11,11 @@ in {
       type = types.derivation;
       description = "The package to be wrapped.";
     };
-    name = {
+    pname = {
       type = types.string;
       defaultFunc = { options }: options.package.pname;
       description = ''
         The name of the package to be wrapped.
-
-        This determines the pname of the wrapped package.
       '';
     };
     extraPaths = {
@@ -32,7 +30,7 @@ in {
 
         This sets the `meta.mainProgram` of the wrapped package, and the default `binaryPath` to wrap with.
       '';
-      defaultFunc = { options }: options.package.meta.mainProgram or options.name;
+      defaultFunc = { options }: options.package.meta.mainProgram or options.pname;
     };
     binaryPath = {
       type = types.string;
@@ -133,7 +131,7 @@ in {
       flagsStr = concatStringsSep " " (map (flag: "--add-flag \"${flag}\"") options.flags);
     in
     stdenvNoCC.mkDerivation {
-      name = "${options.name}-wrapped";
+      name = "${options.pname}-wrapped";
       buildInputs = [ makeBinaryWrapper ];
       paths =
         if options.extraPaths == [] then

--- a/modules/mpv.nix
+++ b/modules/mpv.nix
@@ -96,7 +96,6 @@
     assert !(options ? settings && options ? configFile);
     assert !(options ? keybinds && options ? keybindsFile);
     inputs.mkWrapper {
-      name = "mpv"; # Needs to be hard coded for users of mpv-with-scripts
       inherit (options) package;
       symlinks = {
         "$out/mpv/mpv.conf" =

--- a/modules/nushell.nix
+++ b/modules/nushell.nix
@@ -67,7 +67,6 @@
     in
     assert !(options ? shellInit && options ? configFile);
     inputs.mkWrapper {
-      name = "nu";
       inherit (options) package;
       wrapperArgs =
         if options ? extraPackages then "--prefix PATH : ${makeBinPath options.extraPackages}" else null;

--- a/modules/ripgrep.nix
+++ b/modules/ripgrep.nix
@@ -44,12 +44,10 @@
     assert !(options ? flags && options ? configFile);
     if options ? flags then
       inputs.mkWrapper {
-        name = "rg";
         inherit (options) package flags;
       }
     else
       inputs.mkWrapper {
-        name = "rg";
         environment = {
           RIPGREP_CONFIG_PATH = options.configFile or null;
         };

--- a/modules/tealdeer.nix
+++ b/modules/tealdeer.nix
@@ -45,7 +45,6 @@
     assert !(options ? settings && options ? configFile);
     inputs.mkWrapper {
       inherit (options) package;
-      binaryPath = "$out/bin/tldr";
       symlinks = {
         "$out/tealdeer-config/config.toml" =
           if options ? configFile then

--- a/modules/waybar.nix
+++ b/modules/waybar.nix
@@ -96,7 +96,6 @@
     assert !(options ? settings && options ? configFile);
     assert !(options ? barStyle && options ? cssFile);
     inputs.mkWrapper {
-      name = "waybar";
       inherit (options) package;
       flags = configFlag ++ styleFlag;
       environment = {

--- a/modules/zathura.nix
+++ b/modules/zathura.nix
@@ -93,7 +93,6 @@
     in
     assert !(options ? sourceFiles && (options ? settings || options ? keybinds));
     inputs.mkWrapper {
-      name = "zathura";
       inherit (options) package;
       symlinks = {
         "$out/zathura/zathurarc" = writeText "zathurarc" assembledConfig;


### PR DESCRIPTION
Split out `binaryName` from name and have it default with `meta.mainProgram`.
Cleans up all modules to make benefit of this change as well.
All differences in derivations _should_ be from the `mainProgram` being corrected or from using the package's name for the name.

This affects practically every package, but the ones that are changed from default are:
```diff
 {
   alacritty = «derivation /nix/store/n7afh5m22pmmn7ljhni7cs3f9z9xa863-alacritty-wrapped.drv»;
   bat = «derivation /nix/store/s24lcldgfvmjxvlxspn3wbv2xnxxrlnf-bat-0.26.1.drv»;
-  bottom = «derivation /nix/store/a25pfi0w6aivwg0hlfjjab2yy9mcz50q-bottom-wrapped.drv»;
+  bottom = «derivation /nix/store/nd1gdbidblxjf6qyfxcmv2462rr8nbgy-bottom-wrapped.drv»;
   btop = «derivation /nix/store/r4lvwrjj7qmp01sn9x4iaj05k8w5hxc3-btop-wrapped.drv»;
   diff-so-fancy = «derivation /nix/store/bwyak8jgpsa0imh8fniqya6134cz487h-diff-so-fancy-wrapped.drv»;
   direnv = «derivation /nix/store/6z5r657cq2qj53rknbr7d86n4smq5db5-direnv-wrapped.drv»;
   discordo = «derivation /nix/store/5z9vfbzhyvgqvx0f6cx75jsdi56chbhg-discordo-wrapped.drv»;
   dunst = «derivation /nix/store/9j1mnya52vbcb6dpn56dz0y3mvj15bck-dunst-wrapped.drv»;
   eza = «error: attribute 'flags' missing»;
   fastfetch = «derivation /nix/store/bz8x3gq5qijmrd0ipygcick20cnsffil-fastfetch-wrapped.drv»;
   firefox = «derivation /nix/store/hmd24s39458r5dxvka0q75xba3v72dn1-firefox-151.0.4.drv»;
   fish = «derivation /nix/store/3v7jspqihzi00bbkyypcbxbjh5m1giq2-fish-wrapped.drv»;
   fuzzel = «derivation /nix/store/6wd4s1kv6labwghv7c2zc6cvra9mshmq-fuzzel-wrapped.drv»;
   gh = «derivation /nix/store/9vr2dbnkslfrf4gx7rlvhpfvdw9f766c-gh-wrapped.drv»;
   git = «derivation /nix/store/rc2k76l50vnry25f9kpyy5scxnqih9y8-git-wrapped.drv»;
   gitui = «derivation /nix/store/zi5mhmrvs985idh6aqwz2lmh0ajsmqvm-gitui-wrapped.drv»;
-  gnupg = «derivation /nix/store/rn9d1zqmmasdnp4bh2p7y0nz8hqvd468-gpg-wrapped.drv»;
-  helix = «derivation /nix/store/jas73cbc4qn3y4sgsdkxxc7p76hmbl1b-helix-wrapped.drv»;
-  hydrus = «derivation /nix/store/d1ak1npwjq28iasafm4gyhszvqr0ckmp-hydrus-wrapped.drv»;
+  gnupg = «derivation /nix/store/5xnfcrd9h58r18nf6k4n7c90c9fbzdiq-gnupg-wrapped.drv»;
+  helix = «derivation /nix/store/il59ms8wqp9wva1w8x9hq7qq5dpy5i9l-helix-wrapped.drv»;
+  hydrus = «derivation /nix/store/ddpv8akzb2qxmdszj4dsl4dp3kzx0iq3-hydrus-wrapped.drv»;
   hyfetch = «derivation /nix/store/g1zxrvfljffq2alpmnkjg7q7ch1rjmh7-hyfetch-wrapped.drv»;
   irssi = «derivation /nix/store/0rx1lh18srhkns9n3q9scvn6in6f6z7y-irssi-wrapped.drv»;
-  jujutsu = «derivation /nix/store/0kvi35zxwwpmm61r07azgmpgnfsfr45m-jujutsu-wrapped.drv»;
+  jujutsu = «derivation /nix/store/i0ybjapklvmfz8ba4qns7vwf62wx698a-jujutsu-wrapped.drv»;
   kitty = «error: attribute 'theme' missing»;
   less = «derivation /nix/store/bz888nsvrm21v8nyh8nkwhwp69xa3fyq-less-wrapped.drv»;
-  mangowc = «derivation /nix/store/dyd0lb192xnfailv2dy0kw9vr56dlk72-mango-wrapped.drv»;
+  mangowc = «derivation /nix/store/v8g8907dghylvambhqc2hrsic05f1i5c-mangowc-wrapped.drv»;
   mkWrapper = «error: attribute 'package' missing»;
   mpv = «derivation /nix/store/6vpjn97ffdnz25f5higq0b07w2qa2zyc-mpv-wrapped.drv»;
   niri = «derivation /nix/store/8qail3kq7j67n1la0cdyqr0j7v9axc2r-niri-26.04.drv»;
   nixpkgs = «error: attempt to call something which is not a function but a set: { args = { inputs = «thunk»; options = { lib = { add = «thunk»; addContextFrom = «thunk»; addDrvOutputDependencies = «thunk»; addErrorContext = «primop addErrorContext»; addMetaAttrs = «thunk»; all = «primop all»; allUnique = «thunk»; and = «thunk»; any = «primop any»; «485 attributes elided» }; «1 attribute elided» }; }; «5 attributes elided» }»;
-  nushell = «derivation /nix/store/j2h4ynwgb1xaqws9v47zlpy5lapcxvdl-nu-wrapped.drv»;
+  nushell = «derivation /nix/store/36ljyp0jv5nalvi7pk4652l85185r1sq-nushell-wrapped.drv»;
   ripgrep = «error: attribute 'package' missing»;
   satty = «derivation /nix/store/659b90rbalg64hzf83m63g74c3xf7g9m-satty-wrapped.drv»;
   starship = «derivation /nix/store/x8r91pnhly6x42dssznaa9h8ks6x3in8-starship-wrapped.drv»;
   swaybg = «derivation /nix/store/1zl9wdkjl426ynmpd7sxxfphyy4n96b7-swaybg-wrapped.drv»;
   swayidle = «derivation /nix/store/x6xg3kdpc0rij79qnyx90vz7926sds7g-swayidle-wrapped.drv»;
-  tealdeer = «derivation /nix/store/yi6s94i1vnm71azv9vr081v3c08gcdrb-tealdeer-wrapped.drv»;
+  tealdeer = «derivation /nix/store/xsqq50b88wdx4qvrgqm13v0zliklkjb6-tealdeer-wrapped.drv»;
   termfilechooser = «derivation /nix/store/j1k9xkghsk8074my99xaqzhknchw2hqq-xdg-desktop-portal-termfilechooser-wrapped.drv»;
   waybar = «derivation /nix/store/wqxky9r3cnd2lqk84v4h218kwxmcw27b-waybar-wrapped.drv»;
   wezterm = «derivation /nix/store/wsxijr0z0233msy3529javb6pww1pff1-wezterm-wrapped.drv»;
   wiremix = «derivation /nix/store/a3vjnxgnvlwpnmwf6icamzbd5n1d4hzp-wiremix-wrapped.drv»;
   yazi = «derivation /nix/store/fkym7lhv1xcwm1jq0n916dgsrax4aqd8-yazi-wrapped.drv»;
-  zathura = «derivation /nix/store/878kvrnn2mk4s2xzmf8if5gf4nhh8bfw-zathura-wrapped.drv»;
+  zathura = «derivation /nix/store/5g9hamfyh1l21zpmrmqdn6jig1718rfi-zathura-with-plugins-wrapped.drv»;
   zellij = «derivation /nix/store/cnhndxz1n44dv2fzcrbmmlxhy186r0rh-zellij-wrapped.drv»;
   zoxide = «derivation /nix/store/pldpz7mlpd4xc9kib3fmf3hy1dv15wk9-zoxide-wrapped.drv»;
   zsh = «derivation /nix/store/vxdyy3w0wm46mvwb7a4f9jc7k0wppss3-zsh-wrapped.drv»;
 }
```

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned
 - I've only tested the things I use