### PR TITLE
modules/mpv: wrap `umpv`

### DIFF
--- a/modules/mpv.nix
+++ b/modules/mpv.nix
@@ -113,6 +113,9 @@
           else
             null;
       };
+      postWrap = ''
+        wrapProgram $out/bin/umpv --set 'MPV' $out/bin/mpv
+      '';
       environment = {
         XDG_CONFIG_HOME = "$out";
       };


### PR DESCRIPTION
This unfortunately does not work when used in combination with the `mpv-with-scripts` nixpkgs wrapper but we don't default to it so whatever. At some point just copying over the entire thing into this wrapper might be the only nice route for users of it (me).

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
