### PR TITLE
docs: use structured `adios.lib.importModules` args in examples

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -182,7 +182,7 @@ let
   root = {
     modules = adios.lib.inject [
       adios-wrappers
-      (adios.lib.importModules ./wrappers)
+      (adios.lib.importModules { directory = ./wrappers; })
     ];
   };
 ```

--- a/examples/flakes/wrappers.nix
+++ b/examples/flakes/wrappers.nix
@@ -3,7 +3,7 @@ let
   root = {
     modules = adios.lib.inject [
       adios-wrappers
-      (adios.lib.importModules ./wrappers)
+      (adios.lib.importModules { directory = ./wrappers; })
     ];
   };
 

--- a/examples/npins/wrappers.nix
+++ b/examples/npins/wrappers.nix
@@ -3,14 +3,13 @@
   pkgs ? import sources.nixpkgs {},
 }:
 let
-  inherit (pkgs) lib;
   adios = import "${sources.adios}/adios";
   adios-wrappers = import sources.adios-wrappers { inherit adios; };
 
   root = {
     modules = adios.lib.inject [
       adios-wrappers
-      (adios.lib.importModules ./wrappers)
+      (adios.lib.importModules { directory = ./wrappers; })
     ];
   };
 


### PR DESCRIPTION
## Checklist

Also removed an unused `pkgs.lib` from the npins example.

- [ ] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned
