### PR TITLE
mangowc: rename package, as upstream changed package name

### DIFF
--- a/modules/mangowc.nix
+++ b/modules/mangowc.nix
@@ -54,7 +54,7 @@
 
     package = {
       type = types.derivation;
-      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.mangowc;
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.mango;
       description = "The mangowc package to be wrapped.";
     };
   };


### PR DESCRIPTION
Since mangowc got renamed in nixpkgs to mango, this renames it here

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
