### PR TITLE
quickshell: init wrapper

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -707,6 +707,17 @@
     }
   },
 
+  "quickshell": {
+    "configDir": {
+      "description": "Folder containing quickshell configuration files to be injected into the wrapped package. This folder should contain a `shell.qml` file. See the [Quickshell](https://quickshell.org/docs/v0.3.0) docs for more information",
+      "type": "pathLike"
+    },
+    "package": {
+      "description": "The quickshell package to be wrapped.",
+      "type": "derivation"
+    }
+  },
+
   "ripgrep": {
     "configFile": {
       "description": "`ripgreprc` file, containing flags to be automatically appended when running ripgrep. See the documentation of valid flags: https://manpages.ubuntu.com/manpages/jammy/man1/rg.1.html#:~:text=OPTIONS This file should have each flag on its own line. See the documentation of the file's format: https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file Disjoint with the `configFile` option.",

--- a/modules/direnv.nix
+++ b/modules/direnv.nix
@@ -137,6 +137,6 @@
     };
 
   meta = {
-    maintainers = [ "squawky" ];
+    maintainers = [ "Squawkykaka" ];
   };
 }

--- a/modules/helix.nix
+++ b/modules/helix.nix
@@ -146,6 +146,6 @@
     };
 
   meta = {
-    maintainers = [ "squawky" ];
+    maintainers = [ "Squawkykaka" ];
   };
 }

--- a/modules/mangowc.nix
+++ b/modules/mangowc.nix
@@ -105,6 +105,6 @@
     };
 
   meta = {
-    maintainers = [ "squawky" ];
+    maintainers = [ "Squawkykaka" ];
   };
 }

--- a/modules/nushell.nix
+++ b/modules/nushell.nix
@@ -80,6 +80,6 @@
     };
 
   meta = {
-    maintainers = [ "squawky" ];
+    maintainers = [ "Squawkykaka" ];
   };
 }

--- a/modules/quickshell.nix
+++ b/modules/quickshell.nix
@@ -42,6 +42,6 @@
     };
 
   meta = {
-    maintainers = [ "squawky" ];
+    maintainers = [ "Squawkykaka" ];
   };
 }

--- a/modules/quickshell.nix
+++ b/modules/quickshell.nix
@@ -1,0 +1,47 @@
+{ types, ... }:
+{
+  inputs = {
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
+  };
+
+  options = {
+    configDir = {
+      type = types.pathLike;
+      description = ''
+        Folder containing quickshell configuration files to be injected into the wrapped package.
+
+        This folder should contain a `shell.qml` file.
+
+        See the [Quickshell](https://quickshell.org/docs/v0.3.0) docs for more information
+      '';
+    };
+    package = {
+      type = types.derivation;
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.quickshell;
+      description = "The quickshell package to be wrapped.";
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    assert options ? configDir;
+    inputs.mkWrapper {
+      inherit (options) package;
+      symlinks = {
+        "$out/quickshell" = options.configDir;
+      };
+      flags = [
+        "--path"
+        "$out/quickshell"
+      ];
+      postWrap = ''
+        rm $out/bin/qs
+        ln $out/bin/quickshell $out/bin/qs
+      '';
+    };
+
+  meta = {
+    maintainers = [ "squawky" ];
+  };
+}


### PR DESCRIPTION
Add a wrapper for quickshell.
ive chosen not to add a nix-based builder for this, as it doesnt make sense for quickshell.

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
