### PR TITLE
modules/direnv: make nix-direnv an option

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -94,6 +94,10 @@
       "description": "`direnvrc` file to be copied into the wrapped package. The syntax is described at: https://direnv.net/#the-stdlib",
       "type": "string"
     },
+    "nix-direnv": {
+      "description": "The nix-direnv package to integrate with the wrapped package, or null for no integration.",
+      "type": "nullOr<derivation>"
+    },
     "package": {
       "description": "The direnv package to be wrapped.",
       "type": "derivation"

--- a/modules/direnv.nix
+++ b/modules/direnv.nix
@@ -48,6 +48,14 @@
       '';
     };
 
+    nix-direnv = {
+      type = types.nullOr types.derivation;
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.nix-direnv;
+      description = ''
+        The nix-direnv package to integrate with the wrapped package, or null for no integration.
+      '';
+    };
+
     package = {
       type = types.derivation;
       defaultFunc = { inputs }: inputs.nixpkgs.pkgs.direnv;
@@ -106,7 +114,8 @@
   impl =
     { options, inputs }:
     let
-      inherit (inputs.nixpkgs.pkgs) formats writeText nix-direnv;
+      inherit (inputs.nixpkgs.pkgs) formats writeText;
+      inherit (options) nix-direnv;
       generator = formats.toml {};
     in
     assert !(options ? settings && options ? configFile);
@@ -122,7 +131,8 @@
           else
             null;
         # nix-direnv integration
-        "$out/direnv/lib/hm-nix-direnv.sh" = "${nix-direnv}/share/nix-direnv/direnvrc";
+        "$out/direnv/lib/hm-nix-direnv.sh" =
+          if nix-direnv != null then "${nix-direnv}/share/nix-direnv/direnvrc" else null;
         "$out/direnv/direnvrc" =
           if options ? direnvrcFile then
             options.direnvrcFile


### PR DESCRIPTION
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned
