### PR TITLE
modules/niri: change configFile to configFiles

### DIFF
--- a/docs/options.json
+++ b/docs/options.json
@@ -665,9 +665,9 @@
   },
 
   "niri": {
-    "configFile": {
-      "description": "`config.kdl` file to be injected into the wrapped package. See the niri documentation for syntax and valid options: https://github.com/niri-wm/niri/wiki/Configuration:-Introduction",
-      "type": "pathLike"
+    "configFiles": {
+      "description": "A list of `.kdl` files that are included in the wrapped package's config. See the niri documentation for syntax and valid options: https://github.com/niri-wm/niri/wiki/Configuration:-Introduction",
+      "type": "listOf<pathLike>"
     },
     "package": {
       "description": "The niri package to be wrapped.",

--- a/modules/niri.nix
+++ b/modules/niri.nix
@@ -1,4 +1,4 @@
-{ types, ... }:
+{ types, ... } @ adios:
 {
   inputs = {
     mkWrapper.from = { parent }: parent.mkWrapper;
@@ -6,14 +6,15 @@
   };
 
   options = {
-    configFile = {
-      type = types.pathLike;
+    configFiles = {
+      type = types.listOf types.pathLike;
       description = ''
-        `config.kdl` file to be injected into the wrapped package.
+        A list of `.kdl` files that are included in the wrapped package's config.
 
         See the niri documentation for syntax and valid options:
         https://github.com/niri-wm/niri/wiki/Configuration:-Introduction
       '';
+      mergeFunc = adios.lib.merge.lists.concat;
     };
 
     package = {
@@ -25,7 +26,19 @@
 
   impl =
     { options, inputs }:
-    if options ? configFile then
+    if options ? configFiles then
+      let
+        inherit (builtins) concatStringsSep head length;
+        inherit (inputs.nixpkgs.pkgs) writeText;
+
+        configPath =
+          if length options.configFiles == 1 then
+            head options.configFiles
+          else
+            writeText "config.kdl" (
+              concatStringsSep "\n" (map (file: ''include "${file}"'') options.configFiles)
+            );
+      in
       inputs.mkWrapper {
         inherit (options) package;
         # Hack modified and gotten from https://github.com/Lassulus/wrappers/blob/main/modules/niri/module.nix
@@ -36,15 +49,15 @@
           [Service]
           ExecStart=
           ExecStart=$out/bin/niri --session
-          ExecReload=$out/bin/niri msg action load-config-file --path ${options.configFile}
+          ExecReload=$out/bin/niri msg action load-config-file --path ${configPath}
           X-ReloadIfChanged=true
           [Unit]
-          X-Reload-Triggers=${options.configFile}
+          X-Reload-Triggers=${configPath}
           EOF
           cp --remove-destination niri.service $out/share/systemd/user/niri.service
         '';
         environment = {
-          NIRI_CONFIG = options.configFile;
+          NIRI_CONFIG = configPath;
         };
       }
     else


### PR DESCRIPTION
My goal is to have the ability to declaratively manage my niri config, and allow mutations from other modules.  KDL does not represent well in a `settings` nix option, so I wanted to do something like `configContents`. However, while KDL itself allows for duplicate sections, niri performs its own checks and only allows certain sections to be duplicated. The exception to this rule is when the duplicated sections are split into several files.

This change creates a `sourceFiles` options, which takes a list of paths. These paths are then imported into the entrypoint config.kdl file. I have used `optional=true` to avoid warnings when impure paths are non-existent.  Modifiers of this option would need to utilize `writeText`, rather than simply providing a string of kdl lines.

I was considering modifying the existing `configFile` option, but went this route to avoid breaking anyone's config, however I am open to changing that option's type to a union of `types.pathLike` | `types.listOf types.pathLike`. Either route makes sense to me - open to feedback.

If something more robust, like [here](https://github.com/Lassulus/wrappers/blob/f57bc81aa9669871343341b13aa175c8927b6a74/modules/niri/module.nix#L8) is preferred to this route, please let me know.  This just seemed like the most straightforward and simplest way to provide a means of declaratively providing a niri config. 

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
