### PR TITLE
modules/fuzzel: remove `preWrap`

### DIFF
--- a/modules/fuzzel.nix
+++ b/modules/fuzzel.nix
@@ -79,7 +79,6 @@
   impl =
     { options, inputs }:
     let
-      inherit (builtins) head;
       inherit (inputs.nixpkgs.lib) optionals;
       inherit (inputs.nixpkgs.pkgs) formats;
       generator = formats.ini {};
@@ -130,13 +129,6 @@
     inputs.mkWrapper {
       inherit (options) package;
       inherit flags;
-      preWrap =
-        if options ? settings || options ? configFile then
-          ''
-            exec $out/bin/fuzzel --check-config ${head configFlag}
-          ''
-        else
-          "";
     };
 
   meta = {


### PR DESCRIPTION
This check is both broken and also does not support impure paths.

It could be fixed and also check if the config is in the store but generally adios-wrapper's do not do any config validation anyways.

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
