### PR TITLE
wrappers: use XOR for assertions where it's trivial

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -87,16 +87,14 @@ Here's an example module that adds both:
       inherit (inputs.nixpkgs.pkgs) formats;
       generator = formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       symlinks = {
         "$out/foo/foo.toml" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "$out/foo/foo.toml" options.settings
           else
-            null;
+            generator.generate "$out/foo/foo.toml" options.settings;
       };
       environment = {
         FOO_CONFIG_FILE = "$out/foo/foo.toml";

--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -42,17 +42,15 @@
       inherit (inputs.nixpkgs.pkgs) formats;
       generator = formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/alacritty/alacritty.toml" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "alacritty.toml" options.settings
           else
-            null;
+            generator.generate "alacritty.toml" options.settings;
       };
       flags = [
         "--config-file"

--- a/modules/bat.nix
+++ b/modules/bat.nix
@@ -32,20 +32,20 @@
 
   impl =
     { options, inputs }:
-    assert !(options ? flags && options ? configFile);
-    if options ? flags then
-      inputs.mkWrapper {
-        inherit (options) package flags;
-      }
-    else if options ? configFile then
-      inputs.mkWrapper {
-        inherit (options) package;
-        environment = {
-          BAT_CONFIG_PATH = options.configFile;
-        };
-      }
-    else
-      options.package;
+    assert options ? flags != options ? configFile;
+    inputs.mkWrapper (
+      if options ? flags then
+        {
+          inherit (options) package flags;
+        }
+      else
+        {
+          inherit (options) package;
+          environment = {
+            BAT_CONFIG_PATH = options.configFile;
+          };
+        }
+    );
 
   meta = {
     maintainers = [ "llakala" ];

--- a/modules/bluetui.nix
+++ b/modules/bluetui.nix
@@ -42,17 +42,15 @@
       inherit (inputs.nixpkgs) pkgs;
       generator = pkgs.formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/bluetui/config.toml" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "config.toml" options.settings
           else
-            null;
+            generator.generate "config.toml" options.settings;
       };
       environment = {
         XDG_CONFIG_HOME = "$out";

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -42,17 +42,15 @@
       inherit (inputs.nixpkgs.pkgs) formats;
       generator = formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/bottom/bottom.toml" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "bottom.toml" options.settings
           else
-            null;
+            generator.generate "bottom.toml" options.settings;
       };
       environment = {
         XDG_CONFIG_HOME = "$out";

--- a/modules/btop.nix
+++ b/modules/btop.nix
@@ -62,19 +62,17 @@
         } " = ";
       };
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/btop/btop.conf" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            writeText "btop.conf" (toKeyValue options.settings)
           else
-            null;
+            writeText "btop.conf" (toKeyValue options.settings);
       };
-      flags = optionals (options ? configFile || options ? settings) [
+      flags = [
         "--config"
         "$out/btop/btop.conf"
       ];

--- a/modules/fastfetch.nix
+++ b/modules/fastfetch.nix
@@ -40,22 +40,19 @@
     { options, inputs }:
     let
       inherit (inputs.nixpkgs.pkgs) formats;
-      inherit (inputs.nixpkgs.lib) optionals;
       generator = formats.json {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/fastfetch/config.jsonc" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "config.jsonc" options.settings
           else
-            null;
+            generator.generate "config.jsonc" options.settings;
       };
-      flags = optionals (options ? configFile || options ? settings) [
+      flags = [
         "--config"
         "$out/fastfetch/config.jsonc"
       ];

--- a/modules/gnupg.nix
+++ b/modules/gnupg.nix
@@ -40,7 +40,7 @@
     { options, inputs }:
     let
       inherit (inputs.nixpkgs.pkgs) writeText;
-      inherit (inputs.nixpkgs.lib) generators isString optionals optionalString;
+      inherit (inputs.nixpkgs.lib) generators isString optionalString;
       # Copied from https://github.com/nix-community/home-manager/blob/master/modules/programs/gpg.nix#L19-L25
       toKeyValue =
         settings:
@@ -49,19 +49,17 @@
           listsAsDuplicateKeys = true;
         } settings;
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/gnupg/gpg.conf" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            writeText "gpg.conf" (toKeyValue options.settings)
           else
-            null;
+            writeText "gpg.conf" (toKeyValue options.settings);
       };
-      flags = optionals (options ? configFile || options ? settings) [
+      flags = [
         "--options"
         "$out/gnupg/gpg.conf"
       ];

--- a/modules/hyfetch.nix
+++ b/modules/hyfetch.nix
@@ -42,22 +42,19 @@
     { options, inputs }:
     let
       inherit (inputs.nixpkgs.pkgs) formats;
-      inherit (inputs.nixpkgs.lib) optionals;
       generator = formats.json {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/hyfetch/hyfetch.json" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "hyfetch.json" options.settings
           else
-            null;
+            generator.generate "hyfetch.json" options.settings;
       };
-      flags = optionals (options ? configFile || options ? settings) [
+      flags = [
         "--config-file"
         "$out/hyfetch/hyfetch.json"
       ];

--- a/modules/less.nix
+++ b/modules/less.nix
@@ -46,7 +46,7 @@
     let
       inherit (builtins) concatStringsSep;
     in
-    assert !(options ? flags && options ? configFile);
+    assert options ? flags != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       environment = {

--- a/modules/ripgrep.nix
+++ b/modules/ripgrep.nix
@@ -41,17 +41,20 @@
 
   impl =
     { options, inputs }:
-    assert !(options ? flags && options ? configFile);
-    if options ? flags then
-      inputs.mkWrapper {
-        inherit (options) package flags;
-      }
-    else
-      inputs.mkWrapper {
-        environment = {
-          RIPGREP_CONFIG_PATH = options.configFile or null;
-        };
-      };
+    assert options ? flags != options ? configFile;
+    inputs.mkWrapper (
+      if options ? flags then
+        {
+          inherit (options) package flags;
+        }
+      else
+        {
+          inherit (options) package;
+          environment = {
+            RIPGREP_CONFIG_PATH = options.configFile or null;
+          };
+        }
+    );
 
   meta = {
     maintainers = [ "llakala" ];

--- a/modules/satty.nix
+++ b/modules/satty.nix
@@ -40,22 +40,19 @@
     { options, inputs }:
     let
       inherit (inputs.nixpkgs.pkgs) formats;
-      inherit (inputs.nixpkgs.lib) optionals;
       generator = formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/satty/config.toml" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "config.toml" options.settings
           else
-            null;
+            generator.generate "config.toml" options.settings;
       };
-      flags = optionals (options ? configFile || options ? settings) [
+      flags = [
         "--config"
         "$out/satty/config.toml"
       ];

--- a/modules/starship.nix
+++ b/modules/starship.nix
@@ -46,16 +46,14 @@
           inherit (adios.lib) merge;
           generator = formats.toml {};
           default =
-            assert !(options ? settings && options ? configFile);
+            assert options ? settings != options ? configFile;
             {
               inherit (options) package;
               environment.STARSHIP_CONFIG =
                 if options ? configFile then
                   options.configFile
-                else if options ? settings then
-                  generator.generate "starship.toml" options.settings
                 else
-                  null;
+                  generator.generate "starship.toml" options.settings;
             };
         in
         # Allow mutators to change the default value, with the mutators taking

--- a/modules/tealdeer.nix
+++ b/modules/tealdeer.nix
@@ -42,17 +42,15 @@
       inherit (inputs.nixpkgs.pkgs) formats;
       generator = formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/tealdeer-config/config.toml" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "config.toml" options.settings
           else
-            null;
+            generator.generate "config.toml" options.settings;
       };
       environment = {
         TEALDEER_CONFIG_DIR = "$out/tealdeer-config";

--- a/modules/termfilechooser.nix
+++ b/modules/termfilechooser.nix
@@ -38,7 +38,7 @@
       inherit (inputs.nixpkgs.pkgs) formats;
       generator = formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       binaryPath = "$out/libexec/xdg-desktop-portal-termfilechooser";
@@ -46,10 +46,8 @@
         "$out/xdg-desktop-portal-termfilechooser/config" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            (generator.generate "config" options.settings)
           else
-            null;
+            (generator.generate "config" options.settings);
       };
       environment = {
         XDG_CONFIG_HOME = "$out";

--- a/modules/wiremix.nix
+++ b/modules/wiremix.nix
@@ -42,17 +42,15 @@
       inherit (inputs.nixpkgs) pkgs;
       generator = pkgs.formats.toml {};
     in
-    assert !(options ? settings && options ? configFile);
+    assert options ? settings != options ? configFile;
     inputs.mkWrapper {
       inherit (options) package;
       symlinks = {
         "$out/wiremix/wiremix.toml" =
           if options ? configFile then
             options.configFile
-          else if options ? settings then
-            generator.generate "wiremix.toml" options.settings
           else
-            null;
+            generator.generate "wiremix.toml" options.settings;
       };
       environment = {
         XDG_CONFIG_HOME = "$out";


### PR DESCRIPTION
cc: @aabush64 @Coca162 

By asserting that the values aren't equal, we can guarantee that only one of them is set, and ignore the possiblity that none are set. I only applied this to modules that only define two disjoint options (think `settings` and `configFile`. Any modules that had more options (like `theme`) could hypothetically be called with that other option, and have the primary option ignored. We can think about those in the future.

## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned (I got the same hash for my devshell)