### PR TITLE
modules: add es-sai-fi as maintainer of relevant modules

### DIFF
--- a/modules/alacritty.nix
+++ b/modules/alacritty.nix
@@ -59,4 +59,8 @@
         "$out/alacritty/alacritty.toml"
       ];
     };
+
+  meta = {
+    maintainers = [ "es-sai-fi" ];
+  };
 }

--- a/modules/bottom.nix
+++ b/modules/bottom.nix
@@ -58,4 +58,8 @@
         XDG_CONFIG_HOME = "$out";
       };
     };
+
+  meta = {
+    maintainers = [ "es-sai-fi" ];
+  };
 }

--- a/modules/jujutsu.nix
+++ b/modules/jujutsu.nix
@@ -75,4 +75,8 @@
         JJ_CONFIG = "$out/jj-config";
       };
     };
+
+  meta = {
+    maintainers = [ "es-sai-fi" ];
+  };
 }

--- a/modules/tealdeer.nix
+++ b/modules/tealdeer.nix
@@ -58,4 +58,8 @@
         TEALDEER_CONFIG_DIR = "$out/tealdeer-config";
       };
     };
+
+  meta = {
+    maintainers = [ "es-sai-fi" ];
+  };
 }


### PR DESCRIPTION
cc @es-sai-fi. I mentioned this to you months ago and then forgot. You mentioned even though you're not using adios-wrappers anymore, you're still keeping an eye.
## Checklist

- [x] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
