### PR TITLE
remove wrapper command from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
 ## Checklist
 
-- [ ] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
 - [ ] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
 - [ ] I tested my wrapper to make sure it functioned


### PR DESCRIPTION
## Checklist
Removes the 
```
- [ ] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`\
```

line from the pr template, since its no longer needed
- [ ] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned
