### PR TITLE
modules/noctalia: init

### DIFF
--- a/modules/noctalia.nix
+++ b/modules/noctalia.nix
@@ -1,0 +1,63 @@
+{ types, ... }:
+{
+  inputs = {
+    mkWrapper.from = { parent }: parent.mkWrapper;
+    nixpkgs.from = { parent }: parent.nixpkgs;
+  };
+
+  options = {
+    settings = {
+      type = types.attrs;
+      description = ''
+        Settings to be injected into the wrapped package's `config.toml`.
+
+        See the noctalia docs for valid options:
+        https://docs.noctalia.dev/v5
+
+        Disjoint with the `configFile` option.
+      '';
+    };
+    configFile = {
+      type = types.pathLike;
+      description = ''
+        `config.toml` file to be injected into the wrapped package.
+
+        See the noctalia docs for valid options:
+        https://docs.noctalia.dev/v5
+
+        Disjoint with the `settings` option.
+      '';
+    };
+    package = {
+      type = types.derivation;
+      description = "The noctalia package to be wrapped.";
+      defaultFunc = { inputs }: inputs.nixpkgs.pkgs.noctalia;
+    };
+  };
+
+  impl =
+    { options, inputs }:
+    let
+      generator = inputs.nixpkgs.pkgs.formats.toml {};
+    in
+    assert !(options ? settings && options ? configFile);
+    inputs.mkWrapper {
+      inherit (options) package;
+      symlinks = {
+        "$out/noctalia/noctalia.toml" =
+          if options ? configFile then
+            options.configFile
+          else if options ? settings then
+            generator.generate "noctalia.toml" options.settings
+          else
+            null;
+      };
+      environment = {
+        NOCTALIA_CONFIG_HOME = "$out";
+      };
+    };
+
+  meta = {
+    maintainers = [ "pengo" ];
+  };
+}


### PR DESCRIPTION
## Checklist

- [ ] If I added/changed any options, I ran `./dev/generate-docs.sh > docs/options.json`
  ^ does this still apply?
- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned

updated version of #51 