### PR TITLE
modules/kitty: optional theme

### DIFF
--- a/modules/kitty.nix
+++ b/modules/kitty.nix
@@ -96,8 +96,12 @@
             null;
 
         "$out/kitty/current-theme.conf" =
-          options.themeFile
-            or "${inputs.nixpkgs.pkgs.kitty-themes}/share/kitty-themes/themes/${options.theme}.conf";
+          if options ? themeFile then
+            options.themeFile
+          else if options ? theme then
+            "${inputs.nixpkgs.pkgs.kitty-themes}/share/kitty-themes/themes/${options.theme}.conf"
+          else
+            null;
       };
       environment = {
         KITTY_CONFIG_DIRECTORY = "$out/kitty";


### PR DESCRIPTION
Make wrapper not assume `theme` or `themeFile` is set in configuration, in case user sets every color in `kitty.conf`, making wrapper look better for the user. The unused `current-theme.conf` is also not created, which is a plus.

This is my first PR to adios-wrappers, if there is anything that should be changed, please point at it.
## Checklist

- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
