### PR TITLE
modules/anyrun: fix environment inheritance issue

### DIFF
--- a/modules/anyrun.nix
+++ b/modules/anyrun.nix
@@ -101,9 +101,10 @@
         )
       );
 
-      environment = {
-        XDG_CONFIG_HOME = "$out";
-      };
+      flags = [
+        "--config-dir"
+        "$out/anyrun"
+      ];
     };
 
   meta = {


### PR DESCRIPTION
In certain cases, Anyrun's internal `XDG_CONFIG_HOME` variable might be used instead of the regular one (usually set to ~/.config), leading to some apps launched through it to try and write to the Nix Store and subsequently crash. This commit fixes said bug by passing Anyrun's config via a flag instead of using an environment variable.

## Checklist

- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [x] I tested my wrapper to make sure it functioned
