### PR TITLE
site: always use a trailing slash

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -5,4 +5,5 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
   site: 'https://llakala.github.io',
   base: '/adios-wrappers',
+  trailingSlash: 'always',
 });

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -19,7 +19,7 @@ let modules = await getCollection("modules");
     {
       modules.map((mod) => (
         <li>
-          <a href={`${import.meta.env.BASE_URL}/modules/${mod.id}`}>{mod.id}</a>
+          <a href={`${import.meta.env.BASE_URL}modules/${mod.id}/`}>{mod.id}</a>
         </li>
       ))
     }

--- a/site/src/pages/modules/[id].astro
+++ b/site/src/pages/modules/[id].astro
@@ -38,7 +38,7 @@ let exists = res.ok;
     <title>{id} - adios-wrappers</title>
   </Fragment>
 
-  <p><a href="../">&lt; Back</a></p>
+  <p><a href="../..">&lt; Back</a></p>
 
   <h1 class="id">
     {id}


### PR DESCRIPTION
This fixes issues where the back button works locally, but not on the site. Thanks to adk for the patch!

## Checklist

- [ ] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned
