### PR TITLE
dev/generate-docs.nix: add ability to disable doc gen per module

### DIFF
--- a/dev/generate-docs.nix
+++ b/dev/generate-docs.nix
@@ -1,10 +1,12 @@
 let
-  inherit (builtins) mapAttrs getFlake;
+  inherit (builtins) attrNames filter mapAttrs getFlake;
   flake = getFlake (toString ../.);
   keysToRemove = [
     "defaultFunc"
     "mergeFunc"
   ];
+
+  filterAttrValues = pred: set: removeAttrs set (filter (name: !pred set.${name}) (attrNames set));
 in
 mapAttrs (_: wrapper: {
   options = mapAttrs (
@@ -14,4 +16,4 @@ mapAttrs (_: wrapper: {
       type = option.type.name;
     }
   ) wrapper.options;
-}) flake.wrapperModules
+}) (filterAttrValues (wrapper: (wrapper.meta.renderDocs or null) != false) flake.wrapperModules)


### PR DESCRIPTION
A module will now no longer appear in the documentation, if `meta.document` is set to `false` within said module. Useful for deprecations, or potential future helper modules, etc.

## Checklist

- [x] I checked [contributing.md](../docs/contributing.md) and my changes conform to it
- [ ] I tested my wrapper to make sure it functioned
